### PR TITLE
Expand type coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Test
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - run: corepack enable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Test
+        run: npm test
+
+      - name: E2E Test
+        run: npm run e2e
+
+      - name: Build
+        run: npm run build
+
+      - name: "Pre-publish"
+        run: npx pkg-pr-new publish

--- a/README.md
+++ b/README.md
@@ -437,6 +437,119 @@ class ExampleComponent extends IsolatedComponent<{
 
 The `adoptedStyles` property is key, as this will efficiently allow every style declared in your stylesheet to be accessed from inside the Shadow DOM.
 
+## Setup
+
+Getting this working in a real project involves three pieces: installing the package, wiring up code generation, and making your bundler and Elm compiler aware of the generated files. There is also one important bundler gotcha covered at the end.
+
+### 1. Install
+
+```sh
+npm install elm-webcomponents
+```
+
+The package ships both a runtime (the `CustomElement`/`IsolatedCustomElement` base classes and decorators, which _are_ bundled into your client) and a CLI (`elm-webcomponents`, used only at build time for code generation).
+
+### 2. Author your components
+
+Put your annotated component files somewhere your bundler will include them (e.g. import them from your entry point so they get registered). We recommend keeping them in a dedicated directory — say `src/components/` — because the code generator globs over them.
+
+### 3. Wire up code generation
+
+Run the CLI over your component files, pointing `-o` at an output directory for the generated Elm:
+
+```sh
+elm-webcomponents -o generated/elm src/components/*.ts
+```
+
+The generated modules are meant to be committed-or-regenerated, not hand-edited. It's convenient to run this as part of your existing codegen step, and to format the output afterwards:
+
+```jsonc
+// package.json
+{
+  "scripts": {
+    "codegen": "elm-webcomponents -o generated/elm src/components/*.ts && elm-format generated/elm --yes",
+  },
+}
+```
+
+> [!TIP]
+> The CLI does not create the output directory for you, so make sure it exists (e.g. commit a `.gitkeep`, or `mkdir -p` first).
+
+### 4. Tell Elm about the generated modules
+
+The generated modules use **flat module names** (e.g. `SizeObserver`, not `Components.SizeObserver`). Elm requires a module's name to match its path _relative to a source directory_, so the output directory must itself be a source directory. Add it to your `elm.json`:
+
+```jsonc
+// elm.json
+{
+  "source-directories": [
+    "src",
+    "generated/elm", // <- the -o directory from step 3
+  ],
+}
+```
+
+If you use `elm-review`, you'll also want to exclude the generated directory, since the output isn't meant to satisfy every lint (e.g. it may import `Json.Encode` even for a component that only has events):
+
+```elm
+-- review/src/ReviewConfig.elm
+config =
+    [ {- your rules -} ]
+        |> List.map (Review.Rule.ignoreErrorsForDirectories [ "generated/elm" ])
+```
+
+### 5. Make your bundler transform the decorators
+
+This library uses **standard (TC39) decorators** and the `accessor` keyword. Your bundler must down-level these to something browsers run today — and **not every bundler does**. Two things to watch for:
+
+- **TypeScript config:** you _must not_ enable `experimentalDecorators` (that opts into the old, incompatible decorator semantics). Leave it off. See the [Compatibility](#typescript) section below.
+- **The bundler's transformer:** some transformers pass standard decorators through untouched, which then throw in the browser.
+
+`esbuild` (and therefore the default Vite pipeline in most setups) lowers standard decorators correctly when targeting `es2022` or similar — nothing extra is needed there.
+
+> [!WARNING]
+> **Vite 8 / Rolldown and `@vitejs/plugin-react` use `oxc`, which (as of writing) does _not_ lower standard decorators** — it only supports the legacy flavor. If your components render but you see raw `@component(...)`/`accessor` in the served/built output, or a `SyntaxError` in the browser, this is why. Setting `esbuild.target` in your Vite config does _not_ help, because `oxc`/`plugin-react` handles `.ts` before esbuild ever runs.
+>
+> The fix is a small `enforce: "pre"` plugin that runs `esbuild` on your component files _before_ the oxc transform sees them:
+>
+> ```ts
+> // vite.config.ts
+> import { transform } from "esbuild";
+>
+> const ewcDecorators = () => ({
+>   name: "ewc-decorators",
+>   enforce: "pre" as const,
+>   async transform(code: string, id: string) {
+>     // scope this to wherever your annotated components live
+>     if (!/\/components\/.*\.ts$/.test(id)) return null;
+>     const result = await transform(code, {
+>       loader: "ts",
+>       target: "es2022",
+>       sourcefile: id,
+>       sourcemap: true,
+>     });
+>     return { code: result.code, map: result.map };
+>   },
+> });
+>
+> export default defineConfig({
+>   plugins: [ewcDecorators() /* , react(), ... */],
+> });
+> ```
+>
+> Keep the file filter tight (only your component directory) so you don't double-transform the rest of your app.
+
+### 6. Register and use
+
+Import your component files from your entry point so the `@component` decorator runs and registers the custom elements:
+
+```ts
+// index.ts
+import "./components/size-observer";
+```
+
+Then use the generated Elm module as shown throughout this README. If you use the [Shadow DOM style-piercing](#problems-of-shadow-dom-and-style-piercing) approach, also make sure your stylesheet is imported as a constructed stylesheet as described there.
+
 ## Compatibility
 
 ### TypeScript

--- a/README.md
+++ b/README.md
@@ -13,11 +13,19 @@ Let's look at an example of a simple `SizeObserver` web component:
 ```typescript
 import { CustomElement, component, optional } from "elm-webcomponents";
 
+/**
+ * The dimensions of the element being observed.
+ */
+interface Box {
+  width: number;
+  height: number;
+}
+
 /** Observes an element and triggers events whenever the contents size changes. */
 @component("size-observer")
 class SizeObserver extends CustomElement<{
   requiredEvents: {
-    sizeChange: { width: number; height: number };
+    sizeChange: Box;
   };
   htmlContent: "single";
   viewFnName: "container";
@@ -55,19 +63,25 @@ class SizeObserver extends CustomElement<{
 When you run this tool, you will get the following file generated for you:
 
 ```elm
-module SizeObserver exposing (view, debounce)
+module SizeObserver exposing (container, debounce, Box)
 
 {-| Observes an element and triggers events whenever the contents size changes.
 
-@docs container, debounce
+@docs container, debounce, Box
 
 -}
 
-import Html exposing (Html)
-import Html.Attributes exposing (Attribute)
+import Html exposing (Attribute, Html)
+import Html.Attributes
 import Html.Events
 import Json.Decode as Decode
 import Json.Encode as Encode
+
+
+{-| The dimensions of the element being observed.
+-}
+type alias Box =
+    { width : Float, height : Float }
 
 
 {-| Number of milliseconds to debounce.
@@ -78,18 +92,14 @@ debounce val =
 
 
 {-| -}
-container :
-    List (Attribute msg)
-    -> { onSizeChange : { width : Float, height : Float } -> msg }
-    -> Html msg
-    -> Html msg
+container : List (Attribute msg) -> { onSizeChange : Box -> msg } -> Html msg -> Html msg
 container attrs req child =
     Html.node "size-observer"
         (Html.Events.on "sizeChange"
             (Decode.map req.onSizeChange
-                (Decode.map2 (\width height -> { width = width, height = height })
-                    (Decode.field "width" Decode.float)
-                    (Decode.field "height" Decode.height)
+                (Decode.succeed (\width height -> { width = width, height = height })
+                    |> Decode.map2 (|>) (Decode.field "width" Decode.float)
+                    |> Decode.map2 (|>) (Decode.field "height" Decode.float)
                 )
             )
             :: attrs

--- a/README.md
+++ b/README.md
@@ -445,7 +445,58 @@ Some TypeScript objects can't meaningfully interop with Elm. Generally this mean
 
 This is a pretty fundamental limitation of how Elm works, so this is unlikely to change in the future. The following limitations are more temporary, due to implementation difficulty (but we intend to get these to work eventually, albeit perhaps with limitations of their own):
 
-We don't currently support any form of encoding for custom types on the Elm side, meaning type unions in TypeScript won't work.
+Union types are supported with the following limitations:
+
+- They must be declared inside a `type` alias; anonymous unions are not supported (as we'd need a name for them in Elm).
+
+  Therefore the following won't work:
+
+  ```ts
+  type shape = {
+    name: string;
+    kind: "square" | "triangle";
+  };
+  ```
+
+  but the following will:
+
+  ```ts
+  type shape =
+    | {
+        name: string;
+        kind: "square";
+      }
+    | {
+        name: string;
+        kind: "triangle";
+      };
+  ```
+
+  even though in some sense they are the identical type in TS and will generate in Elm:
+
+  ```elm
+  type Shape
+      = Square { name : String }
+      | Triangle { name : String }
+  ```
+
+- Each member of the union must be either a _string literal type_ or an object type with exactly one string literal property.
+
+  Therefore,
+
+  ```ts
+  type Color = "red" | "green" | "blue" | { tag: "Custom"; rgb: string };
+  ```
+
+  will work, but
+
+  ```ts
+  type Broken = 3 | { tag: "foo"; type: "foo" } | string;
+  ```
+
+  won't.
+
+Intersection types are supported in an experimental and rudimentary way. Best avoided, but they may work.
 
 Finally, `number` is encoded in Elm as `Float`. At the moment there is no way to encode `Int`, but we also plan to investigate ways to deal with this deficiency.
 

--- a/README.md
+++ b/README.md
@@ -441,9 +441,11 @@ Most of the web component APIs are well supported cross browser. `adoptedStyles`
 
 This codebase works by translating a subset of TypeScript types into Elm types/encoders/decoders.
 
-We don't currently support any form of encoding for custom types on the Elm side, meaning type unions in TypeScript won't work.
+Some TypeScript objects can't meaningfully interop with Elm. Generally this means anything that isn't fundamentally composed of primitives, arrays and POJOs (Plain Old JavaScript Object). Think JSON data model. This means that _Classes_ are not supported, nor any built-in classes such as `RegExp` or `Date`, neither with any _Functions_ work, nor any more exotic objects such as `Float32Array` or `Promise`.
 
-We plan to address this in the future. Some more advanced TS type shenanigans will also not work, such as Indexed types and similar. The best supported are things where there is a clear correspondence between Elm and TypeScript types.
+This is a pretty fundamental limitation of how Elm works, so this is unlikely to change in the future. The following limitations are more temporary, due to implementation difficulty (but we intend to get these to work eventually, albeit perhaps with limitations of their own):
+
+We don't currently support any form of encoding for custom types on the Elm side, meaning type unions in TypeScript won't work.
 
 Finally, `number` is encoded in Elm as `Float`. At the moment there is no way to encode `Int`, but we also plan to investigate ways to deal with this deficiency.
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ import {
 @component("my-example")
 class MyExample extends CustomElement<{}> {
   @required
-  accessor foo: string;
+  accessor foo!: string;
 
   @optional
   accessor bar: bool = true;
@@ -160,7 +160,7 @@ These decorators can be applied to auto-accessors, setters and plain properties:
 @component("my-example")
 class MyExample extends CustomElement<{}> {
   @required
-  accessor foo: string;
+  accessor foo!: string;
 
   @required
   set bar(value: string) {
@@ -168,7 +168,7 @@ class MyExample extends CustomElement<{}> {
   }
 
   @required
-  baz: string;
+  baz!: string;
 }
 ```
 
@@ -255,10 +255,10 @@ import { component, required, optional } from "elm-webcomponents";
 @component("example-react")
 class MyComponent extends ReactCustomElement<{}> {
   @required
-  accessor someInput: string;
+  accessor someInput!: string;
 
-  @optiona
-  accessor someOtherInput: boolean;
+  @optional
+  accessor someOtherInput: boolean = false;
 
   render() {
     return (

--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ The generated modules are meant to be committed-or-regenerated, not hand-edited.
 
 ### 4. Tell Elm about the generated modules
 
-The generated modules use **flat module names** (e.g. `SizeObserver`, not `Components.SizeObserver`). Elm requires a module's name to match its path _relative to a source directory_, so the output directory must itself be a source directory. Add it to your `elm.json`:
+By default the generated modules use **flat module names** (e.g. `SizeObserver`, not `Components.SizeObserver`). Elm requires a module's name to match its path _relative to a source directory_, so the output directory must itself be a source directory. Add it to your `elm.json`:
 
 ```jsonc
 // elm.json
@@ -488,6 +488,8 @@ The generated modules use **flat module names** (e.g. `SizeObserver`, not `Compo
   ],
 }
 ```
+
+If you'd rather namespace the generated modules under an existing source directory, pass `--module-prefix` (short `-p`). For example, `elm-webcomponents -o src --module-prefix Components src/components/*.ts` emits `module Components.SizeObserver` into `src/Components/SizeObserver.elm`, so no extra source directory is needed — just make sure the prefix directory sits inside one you already list.
 
 If you use `elm-review`, you'll also want to exclude the generated directory, since the output isn't meant to satisfy every lint (e.g. it may import `Json.Encode` even for a component that only has events):
 
@@ -622,6 +624,8 @@ Union types are supported with the following limitations:
 - There is special case support for `undefined | someType`, which will be translated to `Maybe SomeType`. For this to work, you will need `strictNullChecks` enabled in your tsconfig.
 
 Intersection types are supported in an experimental and rudimentary way. Best avoided, but they may work.
+
+String-keyed dictionaries are supported: a `Record<string, X>` or an index signature `{ [key: string]: X }` is translated to an Elm `Dict String X` (with the corresponding `Json.Encode`/`Json.Decode` code). This only applies when the type has no named properties as well, since Elm dictionaries are homogeneous.
 
 Finally, `number` is encoded in Elm as `Float`. At the moment there is no way to encode `Int`, but we also plan to investigate ways to deal with this deficiency.
 

--- a/README.md
+++ b/README.md
@@ -496,6 +496,8 @@ Union types are supported with the following limitations:
 
   won't.
 
+- There is special case support for `undefined | someType`, which will be translated to `Maybe SomeType`. For this to work, you will need `strictNullChecks` enabled in your tsconfig.
+
 Intersection types are supported in an experimental and rudimentary way. Best avoided, but they may work.
 
 Finally, `number` is encoded in Elm as `Float`. At the moment there is no way to encode `Int`, but we also plan to investigate ways to deal with this deficiency.

--- a/README.md
+++ b/README.md
@@ -631,7 +631,29 @@ Enums are supported and become an Elm custom type with one constructor per membe
 
 Tuples are supported for 2 and 3 elements (e.g. `[string, number]` becomes `( String, Float )`), encoded as a positional JSON array. Elm has no tuples with 4 or more elements, so those are rejected — use a record instead.
 
-Finally, `number` is encoded in Elm as `Float`. At the moment there is no way to encode `Int`, but we also plan to investigate ways to deal with this deficiency.
+Template literal types with a single `string` or `number` placeholder are supported when declared as a named `type` (e.g. `type ItemId = \`item-${string}\``). Their representation depends on direction:
+
+- **Outbound** (a property you pass into the element): the type becomes an opaque Elm type (`type ItemId = ItemId String`) with a smart constructor that returns `Maybe`, rejecting strings that don't match the pattern (here, anything not starting with `item-`). This gives you validation at the point where you construct the value.
+- **Inbound** (a value handed back to you in an event payload): the type becomes a plain `String`. An opaque type would be useless here, since its constructor isn't exposed and you couldn't unwrap the value. (Inbound is also more lenient — anonymous and multi-placeholder template literals are accepted as `String`.)
+
+Anonymous (inline) template literals and multi-placeholder patterns are not supported in the outbound direction, since there'd be no name for the opaque type.
+
+By default `number` is encoded in Elm as `Float`. To generate an Elm `Int` instead, use the exported `Int` type, which is a [branded](https://egghead.io/blog/using-branded-types-in-typescript) `number` (it behaves like a `number` at runtime and in arithmetic, but the generator detects it and emits `Int` with `Encode.int` / `Decode.int`):
+
+```ts
+import { Int } from "elm-webcomponents";
+
+@component("counter-element")
+class Counter extends CustomElement<{}> {
+  @required
+  accessor count!: Int;
+
+  @required
+  accessor size!: { width: Int; height: Int };
+}
+```
+
+Because TypeScript has no distinct integer type, assigning a numeric literal to an `Int` may require a cast, e.g. `this.count = 5 as Int`. The `Int` brand is detected structurally, so it works anywhere a number can appear — nested in records, arrays, tuples, `Dict` values, and so on.
 
 ### Status
 

--- a/README.md
+++ b/README.md
@@ -655,6 +655,34 @@ class Counter extends CustomElement<{}> {
 
 Because TypeScript has no distinct integer type, assigning a numeric literal to an `Int` may require a cast, e.g. `this.count = 5 as Int`. The `Int` brand is detected structurally, so it works anywhere a number can appear — nested in records, arrays, tuples, `Dict` values, and so on.
 
+### Custom Elm types
+
+`Int` is really a special case of a general mechanism: you can map any TypeScript type to an Elm type of your choosing with the `ElmType` brand. This lets you plug in Elm types the generator doesn't know about (e.g. `Time.Posix`). You supply the Elm type name, a decoder, an encoder, and the modules the snippets need:
+
+```ts
+import { ElmType, component, required, CustomElement } from "elm-webcomponents";
+
+type Posix = ElmType<
+  number, // the underlying (runtime) TypeScript type
+  "Time.Posix", // the Elm type expression
+  "Decode.map Time.millisToPosix Decode.int", // a complete `Decoder Time.Posix`
+  "\\p -> Encode.int (Time.posixToMillis p)", // a `Time.Posix -> Encode.Value` function
+  ["Time"] // modules the snippets reference
+>;
+
+@component("clock-element")
+class Clock extends CustomElement<{ requiredEvents: { fire: { at: Posix } } }> {
+  @required
+  accessor start!: Posix;
+}
+```
+
+Generates a module that `import Time`, types `start` as `Time.Posix`, encodes it with your function, and decodes the event payload with your decoder. Like `Int`, the brand is a runtime-transparent version of the underlying type (here `number`), is detected structurally so it works when nested, and its imports are collected and deduplicated across the module. Contract details:
+
+- The **decoder** must be a complete `Json.Decode.Decoder` expression for your Elm type (it is emitted verbatim). It's optional — omit it (or pass `""`) for a type that only flows *out* of Elm (a property). Using such a type in an event payload is then a generation error.
+- The **encoder** must be a function from your Elm type to `Json.Encode.Value` (the generator applies it to the value). It's optional in the same way, for a type that only flows *into* Elm (an event).
+- The **modules** field is a tuple of fully-qualified Elm module names (e.g. `["Time"]`); the generator emits `import <Module>` for each, so they're always imported unqualified (avoiding conflicting-alias problems between usages). `Json.Decode as Decode` and `Json.Encode as Encode` are always in scope. Omit the field (`[]`) if no extra modules are needed.
+
 ### Status
 
 This is beta software. Please report issues as you encounter them.

--- a/README.md
+++ b/README.md
@@ -627,6 +627,10 @@ Intersection types are supported in an experimental and rudimentary way. Best av
 
 String-keyed dictionaries are supported: a `Record<string, X>` or an index signature `{ [key: string]: X }` is translated to an Elm `Dict String X` (with the corresponding `Json.Encode`/`Json.Decode` code). This only applies when the type has no named properties as well, since Elm dictionaries are homogeneous.
 
+Enums are supported and become an Elm custom type with one constructor per member (e.g. `enum Color { Red = "red", Green = "green" }` becomes `type Color = Red | Green`). String enums are encoded/decoded by their string value; numeric enums by their numeric value.
+
+Tuples are supported for 2 and 3 elements (e.g. `[string, number]` becomes `( String, Float )`), encoded as a positional JSON array. Elm has no tuples with 4 or more elements, so those are rejected — use a record instead.
+
 Finally, `number` is encoded in Elm as `Float`. At the moment there is no way to encode `Int`, but we also plan to investigate ways to deal with this deficiency.
 
 ### Status

--- a/elm.json
+++ b/elm.json
@@ -1,22 +1,25 @@
 {
-  "type": "application",
-  "source-directories": ["example/elm-webcomponents", "example/app"],
-  "elm-version": "0.19.1",
-  "dependencies": {
-    "direct": {
-      "elm/browser": "1.0.2",
-      "elm/core": "1.0.5",
-      "elm/html": "1.0.0",
-      "elm/json": "1.1.3"
+    "type": "application",
+    "source-directories": [
+        "example/elm-webcomponents",
+        "example/app"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.5",
+            "elm/html": "1.0.0",
+            "elm/json": "1.1.3",
+            "elm/time": "1.0.0"
+        },
+        "indirect": {
+            "elm/url": "1.0.0",
+            "elm/virtual-dom": "1.0.3"
+        }
     },
-    "indirect": {
-      "elm/time": "1.0.0",
-      "elm/url": "1.0.0",
-      "elm/virtual-dom": "1.0.3"
+    "test-dependencies": {
+        "direct": {},
+        "indirect": {}
     }
-  },
-  "test-dependencies": {
-    "direct": {},
-    "indirect": {}
-  }
 }

--- a/example/component.ts
+++ b/example/component.ts
@@ -20,11 +20,19 @@ type Int = number;
 //   baz: Int;
 // }
 
+/**
+ * The dimensions of the element being observed.
+ */
+interface Box {
+  width: number;
+  height: number;
+}
+
 /** Observes an element and triggers events whenever the contents size changes. */
 @component("size-observer")
 class SizeObserver extends CustomElement<{
   requiredEvents: {
-    sizeChange: { width: number; height: number };
+    sizeChange: Box;
   };
   htmlContent: "single";
   viewFnName: "container";
@@ -117,10 +125,10 @@ export class ReactyThing extends CustomElement<{
   accessor disabled: Value;
 
   @optional
-  accessor el: Placeholder<number> | null;
+  accessor el: Placeholder<number> | undefined;
 
   @lazy
-  accessor value: Placeholder<number> | null;
+  accessor value: Placeholder<number> | undefined;
 
   @required
   accessor test: { foo: string } & { bar: number };

--- a/example/component.ts
+++ b/example/component.ts
@@ -8,15 +8,17 @@ import {
   type HtmlContent,
 } from "../src";
 
+import { Foo } from "./related";
+
 import style from "./app/styles";
 
 type Int = number;
 
-interface Foo {
-  /** bar comment */
-  bar: string;
-  baz: Int;
-}
+// interface Foo {
+//   /** bar comment */
+//   bar: string;
+//   baz: Int;
+// }
 
 /** Observes an element and triggers events whenever the contents size changes. */
 @component("size-observer")

--- a/example/component.ts
+++ b/example/component.ts
@@ -6,13 +6,12 @@ import {
   CustomElement,
   IsolatedCustomElement,
   type HtmlContent,
+  type Int,
 } from "../src";
 
 import { Foo } from "./related";
 
 import style from "./app/styles";
-
-type Int = number;
 
 // interface Foo {
 //   /** bar comment */
@@ -28,6 +27,8 @@ interface Box {
   height: number;
 }
 
+type Size = `${number}px`;
+
 /** Observes an element and triggers events whenever the contents size changes. */
 @component("size-observer")
 class SizeObserver extends CustomElement<{
@@ -39,7 +40,7 @@ class SizeObserver extends CustomElement<{
 }> {
   /** Number of milliseconds to debounce.  */
   @optional
-  accessor debounce: number = 100;
+  accessor debounce: Int = 100 as Int;
 
   #resizeObserver!: ResizeObserver;
   #timeout: ReturnType<typeof setTimeout> | null = null;
@@ -72,7 +73,7 @@ class SizeObserver extends CustomElement<{
 class MyElement extends CustomElement<{
   optionalEvents: {
     /** foo comment */
-    Rendered: { foo: string };
+    Rendered: { foo: string; size: Size };
   };
   htmlContent: {
     header: { mode: "single" };
@@ -86,8 +87,11 @@ class MyElement extends CustomElement<{
   @required
   accessor otherProp!: Foo;
 
+  @required
+  accessor size!: Size;
+
   render() {
-    this.triggerEvent("Rendered", { foo: "bar" });
+    this.triggerEvent("Rendered", { foo: "bar", size: this.size });
     console.log("rendered");
   }
 }

--- a/example/component.ts
+++ b/example/component.ts
@@ -41,8 +41,8 @@ class SizeObserver extends CustomElement<{
   @optional
   accessor debounce: number = 100;
 
-  #resizeObserver: ResizeObserver;
-  #timeout: NodeJS.Timeout | null = null;
+  #resizeObserver!: ResizeObserver;
+  #timeout: ReturnType<typeof setTimeout> | null = null;
   connectedCallback(): void {
     this.#resizeObserver = new ResizeObserver(() => {
       if (this.#timeout == null) {
@@ -84,7 +84,7 @@ class MyElement extends CustomElement<{
 
   /** Some comments */
   @required
-  accessor otherProp: Foo;
+  accessor otherProp!: Foo;
 
   render() {
     this.triggerEvent("Rendered", { foo: "bar" });
@@ -116,13 +116,13 @@ export class ReactyThing extends CustomElement<{
   extraAttributes: false;
   requiredEvents: { click: Value; change: Placeholder<string>[] };
 }> {
-  #root: Root;
+  #root!: Root;
 
   @required
-  accessor placeholders: Placeholder<string>[];
+  accessor placeholders!: Placeholder<string>[];
 
   @required
-  accessor disabled: Value;
+  accessor disabled!: Value;
 
   @optional
   accessor el: Placeholder<number> | undefined;
@@ -131,11 +131,11 @@ export class ReactyThing extends CustomElement<{
   accessor value: Placeholder<number> | undefined;
 
   @required
-  accessor test: { foo: string } & { bar: number };
+  accessor test!: { foo: string } & { bar: number };
 
   /** A dictionary of arbitrary string-keyed values. */
   @optional
-  accessor metadata: Record<string, string>;
+  accessor metadata!: Record<string, string>;
 
   init() {
     this.#root = {

--- a/example/component.ts
+++ b/example/component.ts
@@ -84,10 +84,10 @@ class MyElement extends CustomElement<{
 
 type PlaceholderType = "slot" | "variable" | "context" | "system" | "local";
 
-interface Placeholder {
+interface Placeholder<Data> {
   name: string;
   type: string;
-  dataType: string;
+  dataType: Data;
 }
 
 type Root = {
@@ -99,13 +99,13 @@ export class ReactyThing extends CustomElement<{ extraAttributes: false }> {
   #root: Root;
 
   @required
-  accessor placeholders: Placeholder[];
+  accessor placeholders: Placeholder<string>[];
 
   @required
   accessor disabled: boolean;
 
   @lazy
-  accessor value: Placeholder | null;
+  accessor value: Placeholder<number> | null;
 
   init() {
     this.#root = {

--- a/example/component.ts
+++ b/example/component.ts
@@ -86,26 +86,42 @@ type PlaceholderType = "slot" | "variable" | "context" | "system" | "local";
 
 interface Placeholder<Data> {
   name: string;
-  type: string;
+  type: PlaceholderType;
   dataType: Data;
 }
+
+type Value =
+  | {
+      type: "string_value";
+      value: string;
+    }
+  | { type: "int_value"; value: number };
 
 type Root = {
   html: HTMLElement;
 };
 
 @component("reacty-thing")
-export class ReactyThing extends CustomElement<{ extraAttributes: false }> {
+export class ReactyThing extends CustomElement<{
+  extraAttributes: false;
+  requiredEvents: { click: Value; change: Placeholder<string>[] };
+}> {
   #root: Root;
 
   @required
   accessor placeholders: Placeholder<string>[];
 
   @required
-  accessor disabled: boolean;
+  accessor disabled: Value;
+
+  @optional
+  accessor el: Placeholder<number> | null;
 
   @lazy
   accessor value: Placeholder<number> | null;
+
+  @required
+  accessor test: { foo: string } & { bar: number };
 
   init() {
     this.#root = {

--- a/example/component.ts
+++ b/example/component.ts
@@ -7,6 +7,7 @@ import {
   IsolatedCustomElement,
   type HtmlContent,
   type Int,
+  ElmType,
 } from "../src";
 
 import { Foo } from "./related";
@@ -28,6 +29,14 @@ interface Box {
 }
 
 type Size = `${number}px`;
+
+type Posix = ElmType<
+  number,
+  "Time.Posix",
+  "Decode.map Time.millisToPosix Decode.int", // a complete `Decoder Time.Posix`
+  "\\p -> Encode.int (Time.posixToMillis p)", // a `Time.Posix -> Encode.Value` function
+  ["Time"] // imports the snippets need
+>;
 
 /** Observes an element and triggers events whenever the contents size changes. */
 @component("size-observer")
@@ -136,6 +145,9 @@ export class ReactyThing extends CustomElement<{
 
   @required
   accessor test!: { foo: string } & { bar: number };
+
+  @optional
+  accessor time: Posix = 0 as Posix;
 
   /** A dictionary of arbitrary string-keyed values. */
   @optional

--- a/example/component.ts
+++ b/example/component.ts
@@ -133,6 +133,10 @@ export class ReactyThing extends CustomElement<{
   @required
   accessor test: { foo: string } & { bar: number };
 
+  /** A dictionary of arbitrary string-keyed values. */
+  @optional
+  accessor metadata: Record<string, string>;
+
   init() {
     this.#root = {
       html: document.createElement("div"),

--- a/example/related.ts
+++ b/example/related.ts
@@ -1,0 +1,1 @@
+export type Foo = { foo: string };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,18 @@
 {
   "name": "elm-webcomponents",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "elm-webcomponents",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
+        "@dev-build-deploy/diagnose-it": "^1.4.2",
         "@phenomnomnominal/tsquery": "^6.1.3",
         "cmd-ts": "^0.13.0",
+        "log-syntax-error": "^0.1.1",
         "radash": "^12.1.0",
         "typescript": "^5.6.3"
       },
@@ -19,9 +21,11 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.13",
+        "agadoo": "^3.0.0",
         "elm": "^0.19.1-6",
         "elm-format": "^0.8.7",
         "jest": "^29.7.0",
+        "pkg-pr-new": "^0.0.39",
         "pkgroll": "^2.5.0",
         "ts-jest": "^29.2.5",
         "tsx": "^4.19.1",
@@ -689,6 +693,32 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@dev-build-deploy/diagnose-it": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@dev-build-deploy/diagnose-it/-/diagnose-it-1.4.2.tgz",
+      "integrity": "sha512-ltcI4vL9TjdLnRBWD6ykp0rYQYAJHTfbk/53RmG3SSclXADdZsx0u/6bzRomL1ocb9lJpVLCRvxsI3usmDXISg==",
+      "dependencies": {
+        "@dev-build-deploy/sarif-it": "<1",
+        "chalk": "<5",
+        "diff": "^5.1.0"
+      }
+    },
+    "node_modules/@dev-build-deploy/diagnose-it/node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@dev-build-deploy/sarif-it": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@dev-build-deploy/sarif-it/-/sarif-it-0.2.1.tgz",
+      "integrity": "sha512-NvGhCoIfoz547zRxJn9VwVzqDVxtkt5LL76uGiAIcjR2qLLwrBNOw+cd/JxyD3V7/dgWGYCv3ifwlXvC5wzC/w==",
+      "dependencies": {
+        "@types/sarif": "^2.1.4"
       }
     },
     "node_modules/@elm_binaries/darwin_arm64": {
@@ -1657,6 +1687,269 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@jsdevtools/ez-spawn": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ez-spawn/-/ez-spawn-3.0.4.tgz",
+      "integrity": "sha512-f5DRIOZf7wxogefH03RjMPMdBF7ADTWUMoOs9kaJo06EfwF+aFhMZMDZxHg/Xe12hptN9xoZjGso2fdjapBRIA==",
+      "dev": true,
+      "dependencies": {
+        "call-me-maybe": "^1.0.1",
+        "cross-spawn": "^7.0.3",
+        "string-argv": "^0.3.1",
+        "type-detect": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@octokit/action": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/action/-/action-6.1.0.tgz",
+      "integrity": "sha512-lo+nHx8kAV86bxvOVOI3vFjX3gXPd/L7guAUbvs3pUvnR2KC+R7yjBkA1uACt4gYhs4LcWP3AXSGQzsbeN2XXw==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/auth-action": "^4.0.0",
+        "@octokit/core": "^5.0.0",
+        "@octokit/plugin-paginate-rest": "^9.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^10.0.0",
+        "@octokit/types": "^12.0.0",
+        "undici": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-action": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-action/-/auth-action-4.1.0.tgz",
+      "integrity": "sha512-m+3t7K46IYyMk7Bl6/lF4Rv09GqDZjYmNg8IWycJ2Fa3YE3DE7vQcV6G2hUPmR9NDqenefNJwVtlisMjzymPiQ==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/types": "^13.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-action/node_modules/@octokit/openapi-types": {
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
+      "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g==",
+      "dev": true
+    },
+    "node_modules/@octokit/auth-action/node_modules/@octokit/types": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.7.0.tgz",
+      "integrity": "sha512-BXfRP+3P3IN6fd4uF3SniaHKOO4UXWBfkdR3vA8mIvaoO/wLjGN5qivUtW0QRitBHHMcfC41SLhNVYIZZE+wkA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^23.0.1"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.3.1",
+        "@octokit/request-error": "^5.1.0",
+        "@octokit/types": "^13.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
+      "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g==",
+      "dev": true
+    },
+    "node_modules/@octokit/core/node_modules/@octokit/types": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.7.0.tgz",
+      "integrity": "sha512-BXfRP+3P3IN6fd4uF3SniaHKOO4UXWBfkdR3vA8mIvaoO/wLjGN5qivUtW0QRitBHHMcfC41SLhNVYIZZE+wkA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^23.0.1"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.5.tgz",
+      "integrity": "sha512-ekqR4/+PCLkEBF6qgj8WqJfvDq65RH85OAgrtnVp1mSxaXF03u2xW/hUdweGS5654IlC0wkNYC18Z50tSYTAFw==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint/node_modules/@octokit/openapi-types": {
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
+      "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g==",
+      "dev": true
+    },
+    "node_modules/@octokit/endpoint/node_modules/@octokit/types": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.7.0.tgz",
+      "integrity": "sha512-BXfRP+3P3IN6fd4uF3SniaHKOO4UXWBfkdR3vA8mIvaoO/wLjGN5qivUtW0QRitBHHMcfC41SLhNVYIZZE+wkA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^23.0.1"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.0.tgz",
+      "integrity": "sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/request": "^8.3.0",
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql/node_modules/@octokit/openapi-types": {
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
+      "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g==",
+      "dev": true
+    },
+    "node_modules/@octokit/graphql/node_modules/@octokit/types": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.7.0.tgz",
+      "integrity": "sha512-BXfRP+3P3IN6fd4uF3SniaHKOO4UXWBfkdR3vA8mIvaoO/wLjGN5qivUtW0QRitBHHMcfC41SLhNVYIZZE+wkA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^23.0.1"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+      "dev": true
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.1.tgz",
+      "integrity": "sha512-wfGhE/TAkXZRLjksFXuDZdmGnJQHvtU/joFQdweXUgzo1XwvBCD4o4+75NtFfjfLK5IwLf9vHTfSiU3sLRYpRw==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^12.6.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
+      "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^12.6.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.0.tgz",
+      "integrity": "sha512-9Bb014e+m2TgBeEJGEbdplMVWwPmL1FPtggHQRkV+WVsMggPtEkLKPlcVYm/o8xKLkpJ7B+6N8WfQMtDLX2Dpw==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/endpoint": "^9.0.1",
+        "@octokit/request-error": "^5.1.0",
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.0.tgz",
+      "integrity": "sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
+      "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g==",
+      "dev": true
+    },
+    "node_modules/@octokit/request-error/node_modules/@octokit/types": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.7.0.tgz",
+      "integrity": "sha512-BXfRP+3P3IN6fd4uF3SniaHKOO4UXWBfkdR3vA8mIvaoO/wLjGN5qivUtW0QRitBHHMcfC41SLhNVYIZZE+wkA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^23.0.1"
+      }
+    },
+    "node_modules/@octokit/request/node_modules/@octokit/openapi-types": {
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
+      "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g==",
+      "dev": true
+    },
+    "node_modules/@octokit/request/node_modules/@octokit/types": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.7.0.tgz",
+      "integrity": "sha512-BXfRP+3P3IN6fd4uF3SniaHKOO4UXWBfkdR3vA8mIvaoO/wLjGN5qivUtW0QRitBHHMcfC41SLhNVYIZZE+wkA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^23.0.1"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^20.0.0"
+      }
+    },
     "node_modules/@phenomnomnominal/tsquery": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-6.1.3.tgz",
@@ -1840,6 +2133,23 @@
         "@rollup/pluginutils": "^5.0.1",
         "magic-string": "^0.30.3"
       },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-virtual": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-virtual/-/plugin-virtual-3.0.2.tgz",
+      "integrity": "sha512-10monEYsBp3scM4/ND4LNH5Rxvh3e/cVeL3jWTgZ2SrQ+BmUoQcopVQvnaMcOnykb1VkxUFuDAN+0FnpTFRy2A==",
+      "dev": true,
       "engines": {
         "node": ">=14.0.0"
       },
@@ -2490,6 +2800,11 @@
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
       "dev": true
     },
+    "node_modules/@types/sarif": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
+      "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ=="
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -2512,9 +2827,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -2533,6 +2848,36 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agadoo": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/agadoo/-/agadoo-3.0.0.tgz",
+      "integrity": "sha512-gq+fjT3Ilrhb88Jf+vYMjdO/+3znYfa7vJ4IMLPFsBPUxglnr40Ed3yCLrW6IABdJAedB94b2BkqR6I04lh3dg==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/plugin-virtual": "^3.0.1",
+        "acorn": "^8.8.1",
+        "rollup": "^3.5.0"
+      },
+      "bin": {
+        "agadoo": "cli.js"
+      }
+    },
+    "node_modules/agadoo/node_modules/rollup": {
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
+      "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/ansi-escapes": {
@@ -2724,6 +3069,12 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/before-after-hook": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+      "dev": true
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2803,6 +3154,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
       "dev": true
     },
     "node_modules/callsites": {
@@ -2965,6 +3322,12 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -3030,6 +3393,15 @@
         }
       }
     },
+    "node_modules/decode-uri-component": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.4.1.tgz",
+      "integrity": "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
     "node_modules/dedent": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
@@ -3052,6 +3424,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "dev": true
     },
     "node_modules/detect-libc": {
       "version": "1.0.3",
@@ -3403,6 +3781,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/filter-obj": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-5.1.0.tgz",
+      "integrity": "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/find-elm-dependencies": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/find-elm-dependencies/-/find-elm-dependencies-2.0.4.tgz",
@@ -3585,6 +3975,25 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-ansi/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3618,6 +4027,15 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/import-local": {
@@ -3738,6 +4156,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isbinaryfile": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.4.tgz",
+      "integrity": "sha512-YKBKVkKhty7s8rxddb40oOkuP0NbaeXrQvLin6QMHL7Ypiy2RW9LwOVrVgZRyOrhQlayMd9t+D8yDy8MKFTSDQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
       }
     },
     "node_modules/isexe": {
@@ -4761,6 +5191,72 @@
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "dev": true
     },
+    "node_modules/log-syntax-error": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/log-syntax-error/-/log-syntax-error-0.1.1.tgz",
+      "integrity": "sha512-Ecxo2/Jhx/5nk2JLe31WFasCOYHbeL9tbaPeDrUR+hUK21JbVx/YJlKEShrkTu8vCT9vsQbn1fDQ1mldtw78jw==",
+      "dependencies": {
+        "chalk": "^1.0.0"
+      }
+    },
+    "node_modules/log-syntax-error/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/log-syntax-error/node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/log-syntax-error/node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/log-syntax-error/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/log-syntax-error/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/log-syntax-error/node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4889,6 +5385,18 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz",
+      "integrity": "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "pathe": "^2.0.1",
+        "pkg-types": "^1.3.0",
+        "ufo": "^1.5.4"
       }
     },
     "node_modules/ms": {
@@ -5196,6 +5704,12 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
     },
+    "node_modules/pathe": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.2.tgz",
+      "integrity": "sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w==",
+      "dev": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5233,6 +5747,35 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pkg-pr-new": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/pkg-pr-new/-/pkg-pr-new-0.0.39.tgz",
+      "integrity": "sha512-ItcsHK+4uO0qmjK4RNs6vTWv3xFhbPZd5U6RoYbxRURWNZfH7KvpyqRzaw4GR7de/IjkdHVZHCzQkjnp3VOVdg==",
+      "dev": true,
+      "dependencies": {
+        "@jsdevtools/ez-spawn": "^3.0.4",
+        "@octokit/action": "^6.1.0",
+        "ignore": "^5.3.1",
+        "isbinaryfile": "^5.0.2",
+        "pkg-types": "^1.1.1",
+        "query-registry": "^3.0.1",
+        "tinyglobby": "^0.2.9"
+      },
+      "bin": {
+        "pkg-pr-new": "bin/cli.js"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
       }
     },
     "node_modules/pkgroll": {
@@ -5353,6 +5896,52 @@
           "url": "https://opencollective.com/fast-check"
         }
       ]
+    },
+    "node_modules/query-registry": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/query-registry/-/query-registry-3.0.1.tgz",
+      "integrity": "sha512-M9RxRITi2mHMVPU5zysNjctUT8bAPx6ltEXo/ir9+qmiM47Y7f0Ir3+OxUO5OjYAWdicBQRew7RtHtqUXydqlg==",
+      "dev": true,
+      "dependencies": {
+        "query-string": "^9.0.0",
+        "quick-lru": "^7.0.0",
+        "url-join": "^5.0.0",
+        "validate-npm-package-name": "^5.0.1",
+        "zod": "^3.23.8",
+        "zod-package-json": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/query-string": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-9.1.1.tgz",
+      "integrity": "sha512-MWkCOVIcJP9QSKU52Ngow6bsAWAPlPK2MludXvcrS2bGZSl+T1qX9MZvRIkqUIkGLJquMJHWfsT6eRqUpp4aWg==",
+      "dev": true,
+      "dependencies": {
+        "decode-uri-component": "^0.4.1",
+        "filter-obj": "^5.1.0",
+        "split-on-first": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-7.0.0.tgz",
+      "integrity": "sha512-MX8gB7cVYTrYcFfAnfLlhRd0+Toyl8yX8uBx1MrX7K0jegiz9TumwOK27ldXrgDlHRdVi+MqU9Ssw6dr4BNreg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/radash": {
       "version": "12.1.0",
@@ -5561,6 +6150,18 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/split-on-first": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-3.0.0.tgz",
+      "integrity": "sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -5577,6 +6178,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6.19"
       }
     },
     "node_modules/string-length": {
@@ -5755,6 +6365,45 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.10.tgz",
+      "integrity": "sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.4.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
+      "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
+      "dev": true,
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/tmpl": {
@@ -5949,6 +6598,21 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/ufo": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
+      "integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==",
+      "dev": true
+    },
+    "node_modules/undici": {
+      "version": "6.21.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
+      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
@@ -5966,6 +6630,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+      "dev": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.1",
@@ -5995,6 +6665,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/url-join": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
+      "integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -6027,6 +6706,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/validate-npm-package-name": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
+      "integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/vite": {
@@ -6790,6 +7478,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
+      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-package-json": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/zod-package-json/-/zod-package-json-1.1.0.tgz",
+      "integrity": "sha512-RvEsa3W/NCqEBMtnoE09GRVelA3IqRcKaijEiM6CEGsD19qLurf0HjrYMHwOqImOszlLL0ja63DPJeeU4pm7oQ==",
+      "dev": true,
+      "dependencies": {
+        "zod": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "typecheck": "tsc --noEmit",
     "test": "jest",
     "build": "pkgroll",
+    "prepare": "pkgroll",
     "e2e": "mkdir -p example/elm-webcomponents && tsx src/cli.ts -o example/elm-webcomponents example/component.ts && elm-format --yes example/elm-webcomponents && elm make example/elm-webcomponents/*.elm",
     "dev": "vite dev",
     "prepublishOnly": "agadoo"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-webcomponents",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -23,23 +23,28 @@
     "test": "jest",
     "build": "pkgroll",
     "e2e": "tsx src/cli.ts -o example/elm-webcomponents example/component.ts && elm-format --yes example/elm-webcomponents && elm make example/elm-webcomponents/*.elm",
-    "dev": "vite dev"
+    "dev": "vite dev",
+    "prepublishOnly": "agadoo"
   },
   "author": "",
   "license": "ISC",
   "devDependencies": {
     "@types/jest": "^29.5.13",
+    "agadoo": "^3.0.0",
     "elm": "^0.19.1-6",
     "elm-format": "^0.8.7",
     "jest": "^29.7.0",
+    "pkg-pr-new": "^0.0.39",
     "pkgroll": "^2.5.0",
     "ts-jest": "^29.2.5",
     "tsx": "^4.19.1",
     "vite-plugin-elm": "^3.0.1"
   },
   "dependencies": {
+    "@dev-build-deploy/diagnose-it": "^1.4.2",
     "@phenomnomnominal/tsquery": "^6.1.3",
     "cmd-ts": "^0.13.0",
+    "log-syntax-error": "^0.1.1",
     "radash": "^12.1.0",
     "typescript": "^5.6.3"
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "typecheck": "tsc --noEmit",
     "test": "jest",
     "build": "pkgroll",
-    "e2e": "tsx src/cli.ts -o example/elm-webcomponents example/component.ts && elm-format --yes example/elm-webcomponents && elm make example/elm-webcomponents/*.elm",
+    "e2e": "mkdir -p example/elm-webcomponents && tsx src/cli.ts -o example/elm-webcomponents example/component.ts && elm-format --yes example/elm-webcomponents && elm make example/elm-webcomponents/*.elm",
     "dev": "vite dev",
     "prepublishOnly": "agadoo"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,16 @@ const app = command({
         return "./elm-webcomponents";
       },
     }),
+    modulePrefix: option({
+      type: string,
+      description:
+        "Optional dotted Elm module prefix for generated modules (e.g. 'Components' produces module Components.MyElement in Components/MyElement.elm)",
+      long: "module-prefix",
+      short: "p",
+      defaultValue() {
+        return "";
+      },
+    }),
     inputFiles: restPositionals({
       type: ExistingPath,
       description: "Typescript files containing webcomponents",

--- a/src/elm/decoder.test.ts
+++ b/src/elm/decoder.test.ts
@@ -131,6 +131,19 @@ describe.each([
     "Foo",
     `Decode.int |> Decode.andThen (\\raw -> if raw == 0 then Decode.succeed Red else if raw == 1 then Decode.succeed Green else if raw == 2 then Decode.succeed Blue else Decode.fail "Unexpected Foo")`,
   ],
+  [
+    `type Int = number & { readonly __elmInt__?: never }`,
+    "Int",
+    `Decode.int`,
+  ],
+  [
+    `type Int = number & { readonly __elmInt__?: never };
+     type Point = { x: Int; y: number }`,
+    "Point",
+    `Decode.succeed (\\x y -> { x = x, y = y })
+      |> Decode.map2 (|>) (Decode.field "x" (Decode.int))
+      |> Decode.map2 (|>) (Decode.field "y" (Decode.float))`,
+  ],
 ])("%s type %s converts", (tsTypeDef, tsTypeRef, elmTypeRef) => {
   test("converts types correctly", () => {
     const source = `
@@ -155,6 +168,40 @@ describe.each([
         (stmt as ts.VariableDeclaration).type!
       );
       const elmType = buildDecoder(type, checker, new Map());
+      expect(elmType).toEqual(elmTypeRef);
+    });
+    expect.assertions(1);
+  });
+});
+
+// Template literals are decoded as a plain String: decoders only run inbound,
+// where an opaque newtype (whose constructor is not exposed) would be useless.
+describe.each([
+  ["type Foo = `item-${string}`", "Foo", "Decode.string"],
+  ["type Foo = `${number}px`", "Foo", "Decode.string"],
+])("template literal %s decodes", (tsTypeDef, tsTypeRef, elmTypeRef) => {
+  test("as a plain String", () => {
+    const source = `
+    ${tsTypeDef};
+
+    let target : ${tsTypeRef};
+    `;
+    const host = ts.createCompilerHost({});
+    const orig = host.getSourceFile;
+    host.getSourceFile = (fileName, ...args) => {
+      if (fileName == "input.ts") {
+        return ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest);
+      }
+      return orig(fileName, ...args);
+    };
+
+    const program = ts.createProgram(["input.ts"], { strict: true }, host);
+    const checker = program.getTypeChecker();
+    const ast = program.getSourceFile("input.ts")!;
+    query(ast, "VariableDeclaration").forEach((stmt) => {
+      const node = (stmt as ts.VariableDeclaration).type!;
+      const type = checker.getTypeAtLocation(node);
+      const elmType = buildDecoder(type, checker, new Map(), false, node);
       expect(elmType).toEqual(elmTypeRef);
     });
     expect.assertions(1);

--- a/src/elm/decoder.test.ts
+++ b/src/elm/decoder.test.ts
@@ -22,6 +22,12 @@ describe.each([
     `Decode.succeed (\\if_ -> { if_ = if_ })
       |> Decode.map2 (|>) (Decode.field "if" (Decode.string))`,
   ],
+  ["Record<string, number>", "Decode.dict (Decode.float)"],
+  [
+    "Record<string, { x: number }>",
+    `Decode.dict (Decode.succeed (\\x -> { x = x })
+      |> Decode.map2 (|>) (Decode.field "x" (Decode.float)))`,
+  ],
 ])("simple types %s converts to %s", (tsType, elmType) => {
   test("converts types correctly", () => {
     const source = `

--- a/src/elm/decoder.test.ts
+++ b/src/elm/decoder.test.ts
@@ -1,0 +1,138 @@
+import { buildDecoder } from "./decoder";
+import * as ts from "typescript";
+import { query } from "@phenomnomnominal/tsquery";
+
+describe.each([
+  ["string", "Decode.string"],
+  ["number", "Decode.float"],
+  ["boolean", "Decode.bool"],
+  [
+    "{foo: string}",
+    `Decode.succeed (\\foo -> { foo = foo })
+      |> Decode.map2 (|>) (Decode.field "foo" (Decode.string))`,
+  ],
+  ["number[]", "Decode.list (Decode.float)"],
+  [
+    "{foo: number[]}[]",
+    `Decode.list (Decode.succeed (\\foo -> { foo = foo })
+      |> Decode.map2 (|>) (Decode.field "foo" (Decode.list (Decode.float))))`,
+  ],
+  [
+    "{if: string}",
+    `Decode.succeed (\\if_ -> { if_ = if_ })
+      |> Decode.map2 (|>) (Decode.field "if" (Decode.string))`,
+  ],
+])("simple types %s converts to %s", (tsType, elmType) => {
+  test("converts types correctly", () => {
+    const source = `
+    let target : ${tsType};
+    `;
+    const host = ts.createCompilerHost({});
+    const orig = host.getSourceFile;
+    host.getSourceFile = (fileName, ...args) => {
+      if (fileName == "input.ts") {
+        return ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest);
+      }
+      return orig(fileName, ...args);
+    };
+
+    const program = ts.createProgram(["input.ts"], {}, host);
+    const checker = program.getTypeChecker();
+    const ast = program.getSourceFile("input.ts")!;
+    query(ast, "VariableDeclaration").forEach((stmt) => {
+      const type = checker.getTypeAtLocation(
+        (stmt as ts.VariableDeclaration).type!
+      );
+
+      expect(buildDecoder(type, checker, new Map())).toEqual(elmType);
+    });
+    expect.assertions(1);
+  });
+});
+
+describe.each([
+  [
+    "type Foo = {foo: string}",
+    "Foo",
+    `Decode.succeed (\\foo -> { foo = foo })
+      |> Decode.map2 (|>) (Decode.field "foo" (Decode.string))`,
+  ],
+  // [
+  //   "type Foo = {foo?: string}",
+  //   "Foo",
+  //   `Decode.succeed (\\foo -> { foo = foo })
+  //     |> Decode.map2 (|>) (Decode.field "foo" (Decode.nullable (Decode.string)))`,
+  // ],
+  [
+    "type Foo<P> = {foo: P}",
+    "Foo<number>",
+    `Decode.succeed (\\foo -> { foo = foo })
+      |> Decode.map2 (|>) (Decode.field "foo" (Decode.float))`,
+  ],
+  [
+    "interface Foo {foo: string}",
+    "Foo",
+    `Decode.succeed (\\foo -> { foo = foo })
+      |> Decode.map2 (|>) (Decode.field "foo" (Decode.string))`,
+  ],
+  [
+    "interface foo<P> {foo: P}",
+    "foo<number>",
+    `Decode.succeed (\\foo -> { foo = foo })
+      |> Decode.map2 (|>) (Decode.field "foo" (Decode.float))`,
+  ],
+  [
+    "interface foo<P> {foo: P}",
+    "foo<number>[]",
+    `Decode.list (Decode.succeed (\\foo -> { foo = foo })
+      |> Decode.map2 (|>) (Decode.field "foo" (Decode.float)))`,
+  ],
+  [
+    `type Foo = "bar" | "baz"`,
+    "Foo",
+    `Decode.oneOf [Decode.map (always Bar)  (Decode.string |> Decode.andThen (\\str -> if str == \"bar\" then Decode.succeed str else Decode.fail \"Expected bar\")), Decode.map (always Baz)  (Decode.string |> Decode.andThen (\\str -> if str == \"baz\" then Decode.succeed str else Decode.fail \"Expected baz\"))]`,
+  ],
+  [
+    `type Foo = "bar" | { tag: "baz", value: number }`,
+    "Foo",
+    `Decode.oneOf [Decode.map (always Bar)  (Decode.string |> Decode.andThen (\\str -> if str == "bar" then Decode.succeed str else Decode.fail "Expected bar")), Decode.map Baz (Decode.succeed (\\_ value -> { value = value })
+      |> Decode.map2 (|>) (Decode.field "tag" (Decode.string |> Decode.andThen (\\str -> if str == "baz" then Decode.succeed str else Decode.fail "Expected baz")))
+      |> Decode.map2 (|>) (Decode.field "value" (Decode.float)))]`,
+  ],
+  [
+    `type Foo = { tag: 'foo', value: number } & { name : string }`,
+    "Foo",
+    `Decode.succeed (\\tag value name -> { tag = tag, value = value, name = name })
+      |> Decode.map2 (|>) (Decode.field "tag" (Decode.string |> Decode.andThen (\\str -> if str == "foo" then Decode.succeed str else Decode.fail "Expected foo")))
+      |> Decode.map2 (|>) (Decode.field "value" (Decode.float))
+      |> Decode.map2 (|>) (Decode.field "name" (Decode.string))`,
+  ],
+])("%s type %s converts", (tsTypeDef, tsTypeRef, elmTypeRef) => {
+  test("converts types correctly", () => {
+    const source = `
+    ${tsTypeDef};
+
+    let target : ${tsTypeRef};
+    `;
+    const host = ts.createCompilerHost({});
+    const orig = host.getSourceFile;
+    host.getSourceFile = (fileName, ...args) => {
+      if (fileName == "input.ts") {
+        return ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest);
+      }
+      return orig(fileName, ...args);
+    };
+
+    const program = ts.createProgram(["input.ts"], {}, host);
+    const checker = program.getTypeChecker();
+    const ast = program.getSourceFile("input.ts")!;
+    query(ast, "VariableDeclaration").forEach((stmt) => {
+      const type = checker.getTypeAtLocation(
+        (stmt as ts.VariableDeclaration).type!
+      );
+      const elmType = buildDecoder(type, checker, new Map());
+      expect(elmType).toEqual(elmTypeRef);
+    });
+    expect.assertions(1);
+  });
+});

--- a/src/elm/decoder.test.ts
+++ b/src/elm/decoder.test.ts
@@ -57,12 +57,12 @@ describe.each([
     `Decode.succeed (\\foo -> { foo = foo })
       |> Decode.map2 (|>) (Decode.field "foo" (Decode.string))`,
   ],
-  // [
-  //   "type Foo = {foo?: string}",
-  //   "Foo",
-  //   `Decode.succeed (\\foo -> { foo = foo })
-  //     |> Decode.map2 (|>) (Decode.field "foo" (Decode.nullable (Decode.string)))`,
-  // ],
+  [
+    "type Foo = {foo?: string}",
+    "Foo",
+    `Decode.succeed (\\foo -> { foo = foo })
+      |> Decode.map2 (|>) (Decode.field "foo" (Decode.nullable (Decode.string)))`,
+  ],
   [
     "type Foo<P> = {foo: P}",
     "Foo<number>",
@@ -123,7 +123,7 @@ describe.each([
       return orig(fileName, ...args);
     };
 
-    const program = ts.createProgram(["input.ts"], {}, host);
+    const program = ts.createProgram(["input.ts"], { strict: true }, host);
     const checker = program.getTypeChecker();
     const ast = program.getSourceFile("input.ts")!;
     query(ast, "VariableDeclaration").forEach((stmt) => {

--- a/src/elm/decoder.test.ts
+++ b/src/elm/decoder.test.ts
@@ -132,16 +132,18 @@ describe.each([
     `Decode.int |> Decode.andThen (\\raw -> if raw == 0 then Decode.succeed Red else if raw == 1 then Decode.succeed Green else if raw == 2 then Decode.succeed Blue else Decode.fail "Unexpected Foo")`,
   ],
   [
-    `type Int = number & { readonly __elmInt__?: never }`,
+    `type ElmType<Base, Name extends string, Dec extends string = "", Enc extends string = "", Mods extends readonly string[] = []> = Base & { readonly __elmType__: Name; readonly __elmDecoder__: Dec; readonly __elmEncoder__: Enc; readonly __elmModules__: Mods; };
+     type Int = ElmType<number, "Int", "Decode.int", "Encode.int">`,
     "Int",
-    `Decode.int`,
+    `(Decode.int)`,
   ],
   [
-    `type Int = number & { readonly __elmInt__?: never };
+    `type ElmType<Base, Name extends string, Dec extends string = "", Enc extends string = "", Mods extends readonly string[] = []> = Base & { readonly __elmType__: Name; readonly __elmDecoder__: Dec; readonly __elmEncoder__: Enc; readonly __elmModules__: Mods; };
+     type Int = ElmType<number, "Int", "Decode.int", "Encode.int">;
      type Point = { x: Int; y: number }`,
     "Point",
     `Decode.succeed (\\x y -> { x = x, y = y })
-      |> Decode.map2 (|>) (Decode.field "x" (Decode.int))
+      |> Decode.map2 (|>) (Decode.field "x" ((Decode.int)))
       |> Decode.map2 (|>) (Decode.field "y" (Decode.float))`,
   ],
 ])("%s type %s converts", (tsTypeDef, tsTypeRef, elmTypeRef) => {
@@ -203,6 +205,39 @@ describe.each([
       const type = checker.getTypeAtLocation(node);
       const elmType = buildDecoder(type, checker, new Map(), false, node);
       expect(elmType).toEqual(elmTypeRef);
+    });
+    expect.assertions(1);
+  });
+});
+
+// A custom ElmType brand emits its decoder expression verbatim.
+const ELM_TYPE_DEF = `type ElmType<Base, Name extends string, Dec extends string = "", Enc extends string = "", Mods extends readonly string[] = []> =
+  Base & { readonly __elmType__: Name; readonly __elmDecoder__: Dec; readonly __elmEncoder__: Enc; readonly __elmModules__: Mods; };
+type Posix = ElmType<number, "Time.Posix", "Decode.map Time.millisToPosix Decode.int", "\\\\p -> Encode.int (Time.posixToMillis p)", ["Time"]>;`;
+
+describe.each([
+  ["Posix", `(Decode.map Time.millisToPosix Decode.int)`],
+  ["Posix[]", `Decode.list ((Decode.map Time.millisToPosix Decode.int))`],
+])("custom ElmType %s decodes", (tsTypeRef, elmTypeRef) => {
+  test("via its decoder expression", () => {
+    const source = `${ELM_TYPE_DEF}\n\nlet target : ${tsTypeRef};`;
+    const host = ts.createCompilerHost({});
+    const orig = host.getSourceFile;
+    host.getSourceFile = (fileName, ...args) => {
+      if (fileName == "input.ts") {
+        return ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest);
+      }
+      return orig(fileName, ...args);
+    };
+    const program = ts.createProgram(["input.ts"], { strict: true }, host);
+    const checker = program.getTypeChecker();
+    const ast = program.getSourceFile("input.ts")!;
+    query(ast, "VariableDeclaration").forEach((stmt) => {
+      const node = (stmt as ts.VariableDeclaration).type!;
+      const type = checker.getTypeAtLocation(node);
+      expect(buildDecoder(type, checker, new Map(), false, node)).toEqual(
+        elmTypeRef
+      );
     });
     expect.assertions(1);
   });

--- a/src/elm/decoder.test.ts
+++ b/src/elm/decoder.test.ts
@@ -28,6 +28,14 @@ describe.each([
     `Decode.dict (Decode.succeed (\\x -> { x = x })
       |> Decode.map2 (|>) (Decode.field "x" (Decode.float)))`,
   ],
+  [
+    "[string, number]",
+    `Decode.map2 (\\t0 t1 -> ( t0, t1 )) (Decode.index 0 (Decode.string)) (Decode.index 1 (Decode.float))`,
+  ],
+  [
+    "[string, number, boolean]",
+    `Decode.map3 (\\t0 t1 t2 -> ( t0, t1, t2 )) (Decode.index 0 (Decode.string)) (Decode.index 1 (Decode.float)) (Decode.index 2 (Decode.bool))`,
+  ],
 ])("simple types %s converts to %s", (tsType, elmType) => {
   test("converts types correctly", () => {
     const source = `
@@ -112,6 +120,16 @@ describe.each([
       |> Decode.map2 (|>) (Decode.field "tag" (Decode.string |> Decode.andThen (\\str -> if str == "foo" then Decode.succeed str else Decode.fail "Expected foo")))
       |> Decode.map2 (|>) (Decode.field "value" (Decode.float))
       |> Decode.map2 (|>) (Decode.field "name" (Decode.string))`,
+  ],
+  [
+    `enum Foo { Red = "red", Green = "green" }`,
+    "Foo",
+    `Decode.string |> Decode.andThen (\\raw -> if raw == "red" then Decode.succeed Red else if raw == "green" then Decode.succeed Green else Decode.fail "Unexpected Foo")`,
+  ],
+  [
+    `enum Foo { Red, Green, Blue }`,
+    "Foo",
+    `Decode.int |> Decode.andThen (\\raw -> if raw == 0 then Decode.succeed Red else if raw == 1 then Decode.succeed Green else if raw == 2 then Decode.succeed Blue else Decode.fail "Unexpected Foo")`,
   ],
 ])("%s type %s converts", (tsTypeDef, tsTypeRef, elmTypeRef) => {
   test("converts types correctly", () => {

--- a/src/elm/decoder.ts
+++ b/src/elm/decoder.ts
@@ -7,7 +7,7 @@ import {
   tupleElements,
   templateLiteralInfo,
   propertyTypeNode,
-  isElmInt,
+  customTypeInfo,
 } from "./utils";
 import { TransformError, nodeFromType } from "../error";
 
@@ -32,10 +32,17 @@ export const buildDecoder = (
     throw new TransformError(node ?? nodeFromType(type), message);
   };
 
-  // The branded `Int` type presents as an intersection, so it must be handled
-  // before the Intersection→record case that would treat it as an object.
-  if (isElmInt(type, checker)) {
-    return `Decode.int`;
+  // A user-defined `ElmType<...>` brand (including the built-in `Int`) supplies
+  // its own decoder expression, emitted verbatim. Detected before the
+  // Intersection→record case that would otherwise treat it as an object.
+  const customType = customTypeInfo(type, checker);
+  if (customType) {
+    if (!customType.decoder) {
+      error(
+        `The Elm type "${customType.typeName}" has no decoder, so it cannot be used as an inbound (event) value. Add the decoder argument to its ElmType<...> definition.`
+      );
+    }
+    return `(${customType.decoder})`;
   }
 
   // A template literal type is always decoded as a plain String: decoders only

--- a/src/elm/decoder.ts
+++ b/src/elm/decoder.ts
@@ -62,7 +62,7 @@ export const buildDecoder = (
         .map(
           (prop) =>
             `|> Decode.map2 (|>) (Decode.field "${prop.getName()}" ${buildDecoder(
-              checker.getTypeAtLocation(prop.valueDeclaration),
+              checker.getTypeOfSymbol(prop),
               checker
             )})`
         )

--- a/src/elm/decoder.ts
+++ b/src/elm/decoder.ts
@@ -108,9 +108,21 @@ export const buildDecoder = (
         .join("\n      ")}`;
 
     case ts.TypeFlags.Union:
-      let refType = checker.getDeclaredTypeOfSymbol(
+      let refType = (
         type.aliasSymbol
+          ? checker.getDeclaredTypeOfSymbol(type.aliasSymbol)
+          : type
       ) as ts.UnionType;
+      if (
+        refType.types.length === 2 &&
+        refType.types.some((t) => t.flags === ts.TypeFlags.Undefined)
+      ) {
+        const subtype = refType.types.find(
+          (t) => t.flags !== ts.TypeFlags.Undefined
+        );
+
+        return `Decode.nullable (${buildDecoder(subtype, checker, scope)})`;
+      }
       return `Decode.oneOf [${refType.types
         .map((t) => {
           if (t.isStringLiteral()) {

--- a/src/elm/decoder.ts
+++ b/src/elm/decoder.ts
@@ -1,5 +1,6 @@
 import * as ts from "typescript";
 import { toValueCase, toTypeCase, introduce } from "./utils";
+import { TransformError, nodeFromType } from "../error";
 
 const todo = (name: string) => {
   console.warn(`${name} is not implemented for decoders`);
@@ -17,12 +18,16 @@ export const buildDecoder = (
   let properties: ts.Symbol[];
   let propNames: string[];
 
+  const error = (message: string): never => {
+    throw new TransformError(nodeFromType(type), message);
+  };
+
   switch (type.flags) {
     case ts.TypeFlags.Any:
-      throw new Error("Any type not supported");
+      error("Any type is not supported: its shape is unknown so no decoder can be generated");
     case ts.TypeFlags.Unknown:
-      throw new Error(
-        "The type was Unknown, but we need to know the type to infer an encoder"
+      error(
+        "Unknown type is not supported: its shape is unknown so no decoder can be generated"
       );
     case ts.TypeFlags.String:
       return `Decode.string`;
@@ -36,7 +41,7 @@ export const buildDecoder = (
 
     case ts.TypeFlags.BigInt:
     case ts.TypeFlags.BigIntLiteral:
-      throw new Error("BigInt type not supported");
+      error("BigInt type is not supported: Elm has no BigInt equivalent");
     case ts.TypeFlags.StringLiteral:
       [variable, newScope] = introduce("str", scope);
       let t = type as ts.StringLiteralType;
@@ -52,13 +57,13 @@ export const buildDecoder = (
 
     case ts.TypeFlags.ESSymbol:
     case ts.TypeFlags.UniqueESSymbol:
-      throw new Error("Symbol type not supported");
+      error("Symbol type is not supported: symbols cannot be represented in JSON");
 
     case ts.TypeFlags.Void:
     case ts.TypeFlags.Undefined:
     case ts.TypeFlags.Null:
     case ts.TypeFlags.Never:
-      throw new Error("Emtpy/void types not supported");
+      error("Void/undefined/null/never types are not supported as a decoder target");
 
     case ts.TypeFlags.TypeParameter:
       return todo("TypeParameter");
@@ -69,6 +74,13 @@ export const buildDecoder = (
           checker,
           scope
         )})`;
+      }
+      const stringIndexType = checker.getIndexTypeOfType(
+        type,
+        ts.IndexKind.String
+      );
+      if (stringIndexType && checker.getPropertiesOfType(type).length === 0) {
+        return `Decode.dict (${buildDecoder(stringIndexType, checker, scope)})`;
       }
       properties = checker.getPropertiesOfType(type);
       let propies;
@@ -199,6 +211,10 @@ export const buildDecoder = (
     //   return `Debug.todo`;
 
     default:
-      throw new Error("Advanced types not supported");
+      return error(
+        `Advanced types not supported (${
+          type.flags
+        }): ${checker.typeToString(type)}`
+      );
   }
 };

--- a/src/elm/decoder.ts
+++ b/src/elm/decoder.ts
@@ -1,5 +1,14 @@
 import * as ts from "typescript";
-import { toValueCase, toTypeCase, introduce, enumInfo, tupleElements } from "./utils";
+import {
+  toValueCase,
+  toTypeCase,
+  introduce,
+  enumInfo,
+  tupleElements,
+  templateLiteralInfo,
+  propertyTypeNode,
+  isElmInt,
+} from "./utils";
 import { TransformError, nodeFromType } from "../error";
 
 const todo = (name: string) => {
@@ -11,7 +20,8 @@ export const buildDecoder = (
   type: ts.Type,
   checker: ts.TypeChecker,
   scope: Map<string, number>,
-  omitLiterals = false
+  omitLiterals = false,
+  node?: ts.Node
 ): string => {
   let variable: string, newScope: Map<string, number>;
   //reusable variable declarations
@@ -19,8 +29,22 @@ export const buildDecoder = (
   let propNames: string[];
 
   const error = (message: string): never => {
-    throw new TransformError(nodeFromType(type), message);
+    throw new TransformError(node ?? nodeFromType(type), message);
   };
+
+  // The branded `Int` type presents as an intersection, so it must be handled
+  // before the Intersection→record case that would treat it as an object.
+  if (isElmInt(type, checker)) {
+    return `Decode.int`;
+  }
+
+  // A template literal type is always decoded as a plain String: decoders only
+  // run on inbound (event) values, and an opaque newtype would be useless to the
+  // user since its constructor is not exposed. buildType renders these as
+  // `String` in the inbound direction, so the two stay in sync.
+  if (templateLiteralInfo(type, checker, node)) {
+    return `Decode.string`;
+  }
 
   // Enums (a union of EnumLiteral members) decode the underlying primitive and
   // then map each serialized value to its Elm constructor, failing on anything
@@ -35,7 +59,7 @@ export const buildDecoder = (
       .map(
         (member) =>
           `if ${variable} == ${literal(member.value)} then Decode.succeed ${
-            member.constructor
+            member.ctor
           } else `
       )
       .join("");
@@ -159,7 +183,9 @@ export const buildDecoder = (
             `|> Decode.map2 (|>) (Decode.field "${prop.getName()}" (${buildDecoder(
               checker.getTypeOfSymbol(prop),
               checker,
-              newScope
+              newScope,
+              false,
+              propertyTypeNode(prop)
             )}))`
         )
         .join("\n      ")}`;
@@ -219,7 +245,9 @@ export const buildDecoder = (
             `|> Decode.map2 (|>) (Decode.field "${prop.getName()}" (${buildDecoder(
               checker.getTypeOfSymbol(prop),
               checker,
-              scope
+              scope,
+              false,
+              propertyTypeNode(prop)
             )}))`
         )
         .join("\n      ")}`;

--- a/src/elm/decoder.ts
+++ b/src/elm/decoder.ts
@@ -1,4 +1,5 @@
 import * as ts from "typescript";
+import { toValueCase, toTypeCase, introduce } from "./utils";
 
 const todo = (name: string) => {
   console.warn(`${name} is not implemented for decoders`);
@@ -7,8 +8,15 @@ const todo = (name: string) => {
 
 export const buildDecoder = (
   type: ts.Type,
-  checker: ts.TypeChecker
+  checker: ts.TypeChecker,
+  scope: Map<string, number>,
+  omitLiterals = false
 ): string => {
+  let variable: string, newScope: Map<string, number>;
+  //reusable variable declarations
+  let properties: ts.Symbol[];
+  let propNames: string[];
+
   switch (type.flags) {
     case ts.TypeFlags.Any:
       throw new Error("Any type not supported");
@@ -21,6 +29,7 @@ export const buildDecoder = (
     case ts.TypeFlags.Number:
       return `Decode.float`;
     case ts.TypeFlags.Boolean:
+    case ts.TypeFlags.Boolean | ts.TypeFlags.Union:
       return `Decode.bool`;
     case ts.TypeFlags.Enum:
       return todo("Enum");
@@ -29,8 +38,9 @@ export const buildDecoder = (
     case ts.TypeFlags.BigIntLiteral:
       throw new Error("BigInt type not supported");
     case ts.TypeFlags.StringLiteral:
-      // TODO: Implement string encoder
-      return `Decode.string`;
+      [variable, newScope] = introduce("str", scope);
+      let t = type as ts.StringLiteralType;
+      return `Decode.string |> Decode.andThen (\\${variable} -> if ${variable} == "${t.value}" then Decode.succeed ${variable} else Decode.fail "Expected ${t.value}")`;
 
     case ts.TypeFlags.NumberLiteral:
       // TODO: Implement NumberLiteral
@@ -53,27 +63,97 @@ export const buildDecoder = (
     case ts.TypeFlags.TypeParameter:
       return todo("TypeParameter");
     case ts.TypeFlags.Object:
-      const properties = checker.getPropertiesOfType(type);
-      const propNames = properties.map((prop) => prop.getName());
+      if (checker.isArrayType(type)) {
+        return `Decode.list (${buildDecoder(
+          checker.getTypeArguments(type as ts.TypeReference)[0],
+          checker,
+          scope
+        )})`;
+      }
+      properties = checker.getPropertiesOfType(type);
+      let propies;
+      [propies, newScope] = properties.reduce<
+        [[string, string][], Map<string, number>]
+      >(
+        ([vals, scope], prop) => {
+          if (
+            !omitLiterals ||
+            !checker.getTypeOfSymbol(prop).isStringLiteral()
+          ) {
+            let name = toValueCase(prop.getName());
+            let [newName, newScope] = introduce(name, scope);
+            return [[...vals, [name, newName]], newScope];
+          } else {
+            return [[...vals, [toValueCase(prop.getName()), "_"]], scope];
+          }
+        },
+        [[], scope]
+      );
+
+      return `Decode.succeed (\\${propies
+        .map((p) => p[1])
+        .join(" ")} -> { ${propies
+        .filter((p) => p[1] !== "_")
+        .map((p) => `${p[0]} = ${p[1]}`)
+        .join(", ")} })
+      ${properties
+        .map(
+          (prop) =>
+            `|> Decode.map2 (|>) (Decode.field "${prop.getName()}" (${buildDecoder(
+              checker.getTypeOfSymbol(prop),
+              checker,
+              newScope
+            )}))`
+        )
+        .join("\n      ")}`;
+
+    case ts.TypeFlags.Union:
+      let refType = checker.getDeclaredTypeOfSymbol(
+        type.aliasSymbol
+      ) as ts.UnionType;
+      return `Decode.oneOf [${refType.types
+        .map((t) => {
+          if (t.isStringLiteral()) {
+            return `Decode.map (always ${toTypeCase(t.value)})  (${buildDecoder(
+              t,
+              checker,
+              scope
+            )})`;
+          } else {
+            let prop = t
+              .getProperties()
+              .map((sym) =>
+                checker.getTypeOfSymbolAtLocation(sym, sym.valueDeclaration)
+              )
+              .find((ts) => ts.isStringLiteral())?.value;
+
+            return `Decode.map ${toTypeCase(prop)} (${buildDecoder(
+              t,
+              checker,
+              scope,
+              true
+            )})`;
+          }
+        })
+        .join(", ")}]`;
+
+    case ts.TypeFlags.Intersection:
+      properties = checker.getPropertiesOfType(type);
+      propNames = properties.map((prop) => toValueCase(prop.getName()));
+
       return `Decode.succeed (\\${propNames.join(" ")} -> { ${propNames
         .map((prop) => `${prop} = ${prop}`)
         .join(", ")} })
       ${properties
         .map(
           (prop) =>
-            `|> Decode.map2 (|>) (Decode.field "${prop.getName()}" ${buildDecoder(
+            `|> Decode.map2 (|>) (Decode.field "${prop.getName()}" (${buildDecoder(
               checker.getTypeOfSymbol(prop),
-              checker
-            )})`
+              checker,
+              scope
+            )}))`
         )
         .join("\n      ")}`;
-
-    case ts.TypeFlags.Union:
-      return todo("Union");
-
-    // case ts.TypeFlags.Intersection:
-    //   // TODO: ???
-    //   return `Debug.todo`;
 
     // case ts.TypeFlags.Index:
     //   // TODO: ???

--- a/src/elm/decoder.ts
+++ b/src/elm/decoder.ts
@@ -1,5 +1,5 @@
 import * as ts from "typescript";
-import { toValueCase, toTypeCase, introduce } from "./utils";
+import { toValueCase, toTypeCase, introduce, enumInfo, tupleElements } from "./utils";
 import { TransformError, nodeFromType } from "../error";
 
 const todo = (name: string) => {
@@ -22,6 +22,26 @@ export const buildDecoder = (
     throw new TransformError(nodeFromType(type), message);
   };
 
+  // Enums (a union of EnumLiteral members) decode the underlying primitive and
+  // then map each serialized value to its Elm constructor, failing on anything
+  // unexpected. Emitted on a single line so it parses at any nesting depth.
+  const enumType = enumInfo(type, checker);
+  if (enumType) {
+    [variable, newScope] = introduce("raw", scope);
+    const primitive = enumType.isString ? "Decode.string" : "Decode.int";
+    const literal = (value: string | number) =>
+      enumType.isString ? `"${value}"` : `${value}`;
+    const branches = enumType.members
+      .map(
+        (member) =>
+          `if ${variable} == ${literal(member.value)} then Decode.succeed ${
+            member.constructor
+          } else `
+      )
+      .join("");
+    return `${primitive} |> Decode.andThen (\\${variable} -> ${branches}Decode.fail "Unexpected ${enumType.name}")`;
+  }
+
   switch (type.flags) {
     case ts.TypeFlags.Any:
       error("Any type is not supported: its shape is unknown so no decoder can be generated");
@@ -36,8 +56,7 @@ export const buildDecoder = (
     case ts.TypeFlags.Boolean:
     case ts.TypeFlags.Boolean | ts.TypeFlags.Union:
       return `Decode.bool`;
-    case ts.TypeFlags.Enum:
-      return todo("Enum");
+    // Enums are handled by the enumInfo guard above.
 
     case ts.TypeFlags.BigInt:
     case ts.TypeFlags.BigIntLiteral:
@@ -75,6 +94,32 @@ export const buildDecoder = (
           scope
         )})`;
       }
+
+      // Tuples decode positionally from a JSON array via Decode.index.
+      const tupleTypes = tupleElements(type, checker);
+      if (tupleTypes) {
+        if (tupleTypes.length < 2 || tupleTypes.length > 3) {
+          error(
+            `Tuples with ${tupleTypes.length} elements are not supported; Elm only has 2- and 3-element tuples`
+          );
+        }
+        let tupleScope = scope;
+        const names = tupleTypes.map((_, i) => {
+          let name;
+          [name, tupleScope] = introduce(`t${i}`, tupleScope);
+          return name;
+        });
+        const fields = tupleTypes
+          .map(
+            (el, i) =>
+              `(Decode.index ${i} (${buildDecoder(el, checker, tupleScope)}))`
+          )
+          .join(" ");
+        return `Decode.map${tupleTypes.length} (\\${names.join(
+          " "
+        )} -> ( ${names.join(", ")} )) ${fields}`;
+      }
+
       const stringIndexType = checker.getIndexTypeOfType(
         type,
         ts.IndexKind.String

--- a/src/elm/encoder.test.ts
+++ b/src/elm/encoder.test.ts
@@ -125,15 +125,17 @@ describe.each([
         Blue -> Encode.int 2`,
   ],
   [
-    `type Int = number & { readonly __elmInt__?: never }`,
+    `type ElmType<Base, Name extends string, Dec extends string = "", Enc extends string = "", Mods extends readonly string[] = []> = Base & { readonly __elmType__: Name; readonly __elmDecoder__: Dec; readonly __elmEncoder__: Enc; readonly __elmModules__: Mods; };
+     type Int = ElmType<number, "Int", "Decode.int", "Encode.int">`,
     "Int",
-    `Encode.int value`,
+    `(Encode.int) value`,
   ],
   [
-    `type Int = number & { readonly __elmInt__?: never };
+    `type ElmType<Base, Name extends string, Dec extends string = "", Enc extends string = "", Mods extends readonly string[] = []> = Base & { readonly __elmType__: Name; readonly __elmDecoder__: Dec; readonly __elmEncoder__: Enc; readonly __elmModules__: Mods; };
+     type Int = ElmType<number, "Int", "Decode.int", "Encode.int">;
      type Point = { x: Int; y: number }`,
     "Point",
-    `Encode.object [ ( "x", Encode.int value.x ) , ( "y", Encode.float value.y ) ]`,
+    `Encode.object [ ( "x", (Encode.int) value.x ) , ( "y", Encode.float value.y ) ]`,
   ],
 ])("%s type %s converts", (tsTypeDef, tsTypeRef, elmTypeRef) => {
   test("converts types correctly", () => {
@@ -197,6 +199,42 @@ describe.each([
       const type = checker.getTypeAtLocation(node);
       const elmType = buildEncoder(type, "value", checker, new Map(), 8, node);
       expect(elmType).toEqual(elmTypeRef);
+    });
+    expect.assertions(1);
+  });
+});
+
+// A custom ElmType brand applies its own encoder function to the value.
+const ELM_TYPE_DEF = `type ElmType<Base, Name extends string, Dec extends string = "", Enc extends string = "", Mods extends readonly string[] = []> =
+  Base & { readonly __elmType__: Name; readonly __elmDecoder__: Dec; readonly __elmEncoder__: Enc; readonly __elmModules__: Mods; };
+type Posix = ElmType<number, "Time.Posix", "Decode.map Time.millisToPosix Decode.int", "\\\\p -> Encode.int (Time.posixToMillis p)", ["Time"]>;`;
+
+describe.each([
+  ["Posix", `(\\p -> Encode.int (Time.posixToMillis p)) value`],
+  [
+    "Posix[]",
+    `Encode.list (\\el -> (\\p -> Encode.int (Time.posixToMillis p)) el) value`,
+  ],
+])("custom ElmType %s encodes", (tsTypeRef, elmTypeRef) => {
+  test("via its encoder function", () => {
+    const source = `${ELM_TYPE_DEF}\n\nlet target : ${tsTypeRef};`;
+    const host = ts.createCompilerHost({});
+    const orig = host.getSourceFile;
+    host.getSourceFile = (fileName, ...args) => {
+      if (fileName == "input.ts") {
+        return ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest);
+      }
+      return orig(fileName, ...args);
+    };
+    const program = ts.createProgram(["input.ts"], { strict: true }, host);
+    const checker = program.getTypeChecker();
+    const ast = program.getSourceFile("input.ts")!;
+    query(ast, "VariableDeclaration").forEach((stmt) => {
+      const node = (stmt as ts.VariableDeclaration).type!;
+      const type = checker.getTypeAtLocation(node);
+      expect(buildEncoder(type, "value", checker, new Map(), 8, node)).toEqual(
+        elmTypeRef
+      );
     });
     expect.assertions(1);
   });

--- a/src/elm/encoder.test.ts
+++ b/src/elm/encoder.test.ts
@@ -6,13 +6,21 @@ describe.each([
   ["string", "Encode.string value"],
   ["number", "Encode.float value"],
   ["boolean", "Encode.bool value"],
-  ["{foo: string}", `Encode.object [ ( "foo", Encode.string value.foo )]`],
+  ["{foo: string}", `Encode.object [ ( "foo", Encode.string value.foo ) ]`],
   ["number[]", "Encode.list (\\el -> Encode.float el) value"],
   [
     "{foo: number[]}[]",
-    `Encode.list (\\el -> Encode.object [ ( "foo", Encode.list (\\el1 -> Encode.float el1) el.foo )]) value`,
+    `Encode.list (\\el -> Encode.object [ ( "foo", Encode.list (\\el1 -> Encode.float el1) el.foo ) ]) value`,
   ],
-  ["{if: string}", `Encode.object [ ( "if", Encode.string value.if_ )]`],
+  ["{if: string}", `Encode.object [ ( "if", Encode.string value.if_ ) ]`],
+  [
+    "Record<string, number>",
+    `Encode.dict identity (\\v -> Encode.float v) value`,
+  ],
+  [
+    "Record<string, { x: number }>",
+    `Encode.dict identity (\\v -> Encode.object [ ( "x", Encode.float v.x ) ]) value`,
+  ],
 ])("simple types %s converts to %s", (tsType, elmType) => {
   test("converts types correctly", () => {
     const source = `
@@ -45,35 +53,34 @@ describe.each([
   [
     "type Foo = {foo: string}",
     "Foo",
-    `Encode.object [ ( "foo", Encode.string value.foo )]`,
+    `Encode.object [ ( "foo", Encode.string value.foo ) ]`,
   ],
   [
     "type Foo = {foo?: string}",
     "Foo",
     `Encode.object [ ( "foo", case (value.foo) of
-    Nothing -> Encode.null
-    Just val -> Encode.string val
- )]`,
+        Nothing -> Encode.null
+        Just val -> Encode.string val ) ]`,
   ],
   [
     "type Foo<P> = {foo: P}",
     "Foo<number>",
-    `Encode.object [ ( "foo", Encode.float value.foo )]`,
+    `Encode.object [ ( "foo", Encode.float value.foo ) ]`,
   ],
   [
     "interface Foo {foo: string}",
     "Foo",
-    `Encode.object [ ( "foo", Encode.string value.foo )]`,
+    `Encode.object [ ( "foo", Encode.string value.foo ) ]`,
   ],
   [
     "interface foo<P> {foo: P}",
     "foo<number>",
-    `Encode.object [ ( "foo", Encode.float value.foo )]`,
+    `Encode.object [ ( "foo", Encode.float value.foo ) ]`,
   ],
   [
     "interface foo<P> {foo: P}",
     "foo<number>[]",
-    `Encode.list (\\el -> Encode.object [ ( "foo", Encode.float el.foo )]) value`,
+    `Encode.list (\\el -> Encode.object [ ( "foo", Encode.float el.foo ) ]) value`,
   ],
   [
     `type Foo = "bar" | "baz"`,
@@ -87,15 +94,12 @@ describe.each([
     "Foo",
     `case (value) of
         Bar -> Encode.string "bar"
-        Baz baz -> Encode.object [ ( "tag", Encode.string "baz" )
-    , ( "value", Encode.float baz.value )]`,
+        Baz baz -> Encode.object [ ( "tag", Encode.string "baz" ) , ( "value", Encode.float baz.value ) ]`,
   ],
   [
     `type Foo = { tag: 'foo', value: number } & { name : string }`,
     "Foo",
-    `Encode.object [ ( "tag", Encode.string "foo" )
-    , ( "value", Encode.float value.value )
-    , ( "name", Encode.string value.name )]`,
+    `Encode.object [ ( "tag", Encode.string "foo" ) , ( "value", Encode.float value.value ) , ( "name", Encode.string value.name ) ]`,
   ],
 ])("%s type %s converts", (tsTypeDef, tsTypeRef, elmTypeRef) => {
   test("converts types correctly", () => {

--- a/src/elm/encoder.test.ts
+++ b/src/elm/encoder.test.ts
@@ -50,10 +50,10 @@ describe.each([
   [
     "type Foo = {foo?: string}",
     "Foo",
-    `Encode.object [ ( "foo", case value.foo of 
-        Just string -> Encode.string string 
-        Nothing -> Encode.null 
-        )]`,
+    `Encode.object [ ( "foo", case (value.foo) of
+    Nothing -> Encode.null
+    Just val -> Encode.string val
+ )]`,
   ],
   [
     "type Foo<P> = {foo: P}",
@@ -113,7 +113,7 @@ describe.each([
       return orig(fileName, ...args);
     };
 
-    const program = ts.createProgram(["input.ts"], {}, host);
+    const program = ts.createProgram(["input.ts"], { strict: true }, host);
     const checker = program.getTypeChecker();
     const ast = program.getSourceFile("input.ts")!;
     query(ast, "VariableDeclaration").forEach((stmt) => {

--- a/src/elm/encoder.test.ts
+++ b/src/elm/encoder.test.ts
@@ -21,6 +21,14 @@ describe.each([
     "Record<string, { x: number }>",
     `Encode.dict identity (\\v -> Encode.object [ ( "x", Encode.float v.x ) ]) value`,
   ],
+  [
+    "[string, number]",
+    `(\\( t0, t1 ) -> Encode.list identity [ Encode.string t0, Encode.float t1 ]) value`,
+  ],
+  [
+    "[string, number, boolean]",
+    `(\\( t0, t1, t2 ) -> Encode.list identity [ Encode.string t0, Encode.float t1, Encode.bool t2 ]) value`,
+  ],
 ])("simple types %s converts to %s", (tsType, elmType) => {
   test("converts types correctly", () => {
     const source = `
@@ -100,6 +108,21 @@ describe.each([
     `type Foo = { tag: 'foo', value: number } & { name : string }`,
     "Foo",
     `Encode.object [ ( "tag", Encode.string "foo" ) , ( "value", Encode.float value.value ) , ( "name", Encode.string value.name ) ]`,
+  ],
+  [
+    `enum Foo { Red = "red", Green = "green" }`,
+    "Foo",
+    `case (value) of
+        Red -> Encode.string "red"
+        Green -> Encode.string "green"`,
+  ],
+  [
+    `enum Foo { Red, Green, Blue }`,
+    "Foo",
+    `case (value) of
+        Red -> Encode.int 0
+        Green -> Encode.int 1
+        Blue -> Encode.int 2`,
   ],
 ])("%s type %s converts", (tsTypeDef, tsTypeRef, elmTypeRef) => {
   test("converts types correctly", () => {

--- a/src/elm/encoder.test.ts
+++ b/src/elm/encoder.test.ts
@@ -124,6 +124,17 @@ describe.each([
         Green -> Encode.int 1
         Blue -> Encode.int 2`,
   ],
+  [
+    `type Int = number & { readonly __elmInt__?: never }`,
+    "Int",
+    `Encode.int value`,
+  ],
+  [
+    `type Int = number & { readonly __elmInt__?: never };
+     type Point = { x: Int; y: number }`,
+    "Point",
+    `Encode.object [ ( "x", Encode.int value.x ) , ( "y", Encode.float value.y ) ]`,
+  ],
 ])("%s type %s converts", (tsTypeDef, tsTypeRef, elmTypeRef) => {
   test("converts types correctly", () => {
     const source = `
@@ -148,6 +159,43 @@ describe.each([
         (stmt as ts.VariableDeclaration).type!
       );
       const elmType = buildEncoder(type, "value", checker, new Map());
+      expect(elmType).toEqual(elmTypeRef);
+    });
+    expect.assertions(1);
+  });
+});
+
+// Template literals encode by unwrapping the opaque newtype. They need the
+// reference node to recover the alias name (the constructor to destructure).
+describe.each([
+  [
+    "type Foo = `item-${string}`",
+    "Foo",
+    `(\\(Foo raw) -> Encode.string raw) value`,
+  ],
+])("template literal %s encodes", (tsTypeDef, tsTypeRef, elmTypeRef) => {
+  test("by unwrapping the opaque newtype", () => {
+    const source = `
+    ${tsTypeDef};
+
+    let target : ${tsTypeRef};
+    `;
+    const host = ts.createCompilerHost({});
+    const orig = host.getSourceFile;
+    host.getSourceFile = (fileName, ...args) => {
+      if (fileName == "input.ts") {
+        return ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest);
+      }
+      return orig(fileName, ...args);
+    };
+
+    const program = ts.createProgram(["input.ts"], { strict: true }, host);
+    const checker = program.getTypeChecker();
+    const ast = program.getSourceFile("input.ts")!;
+    query(ast, "VariableDeclaration").forEach((stmt) => {
+      const node = (stmt as ts.VariableDeclaration).type!;
+      const type = checker.getTypeAtLocation(node);
+      const elmType = buildEncoder(type, "value", checker, new Map(), 8, node);
       expect(elmType).toEqual(elmTypeRef);
     });
     expect.assertions(1);

--- a/src/elm/encoder.test.ts
+++ b/src/elm/encoder.test.ts
@@ -1,15 +1,18 @@
-import { buildType } from "./type";
+import { buildEncoder } from "./encoder";
 import * as ts from "typescript";
 import { query } from "@phenomnomnominal/tsquery";
 
 describe.each([
-  ["string", "String"],
-  ["number", "Float"],
-  ["boolean", "Bool"],
-  ["{foo: string}", "{ foo : String }"],
-  ["number[]", "List (Float)"],
-  ["{foo: number[]}[]", "List ({ foo : List (Float) })"],
-  ["{if: string}", "{ if_ : String }"],
+  ["string", "Encode.string value"],
+  ["number", "Encode.float value"],
+  ["boolean", "Encode.bool value"],
+  ["{foo: string}", `Encode.object [ ( "foo", Encode.string value.foo )]`],
+  ["number[]", "Encode.list (\\el -> Encode.float el) value"],
+  [
+    "{foo: number[]}[]",
+    `Encode.list (\\el -> Encode.object [ ( "foo", Encode.list (\\el1 -> Encode.float el1) el.foo )]) value`,
+  ],
+  ["{if: string}", `Encode.object [ ( "if", Encode.string value.if_ )]`],
 ])("simple types %s converts to %s", (tsType, elmType) => {
   test("converts types correctly", () => {
     const source = `
@@ -32,7 +35,7 @@ describe.each([
         (stmt as ts.VariableDeclaration).type!
       );
 
-      expect(buildType(type, checker, stmt).expression).toEqual(elmType);
+      expect(buildEncoder(type, "value", checker, new Map())).toEqual(elmType);
     });
     expect.assertions(1);
   });
@@ -42,58 +45,59 @@ describe.each([
   [
     "type Foo = {foo: string}",
     "Foo",
-    new Map([["Foo", "type alias Foo = { foo : String }"]]),
-    "Foo",
+    `Encode.object [ ( "foo", Encode.string value.foo )]`,
   ],
-  // [
-  //   "type Foo = {foo?: string}",
-  //   "Foo",
-  //   new Map([["Foo", "type alias Foo = { foo : Maybe String }"]]),
-  //   "Foo",
-  // ],
+  [
+    "type Foo = {foo?: string}",
+    "Foo",
+    `Encode.object [ ( "foo", case value.foo of 
+        Just string -> Encode.string string 
+        Nothing -> Encode.null 
+        )]`,
+  ],
   [
     "type Foo<P> = {foo: P}",
     "Foo<number>",
-    new Map([["Foo", "type alias Foo p = { foo : p }"]]),
-    "Foo Float",
+    `Encode.object [ ( "foo", Encode.float value.foo )]`,
   ],
   [
     "interface Foo {foo: string}",
     "Foo",
-    new Map([["Foo", "type alias Foo = { foo : String }"]]),
-    "Foo",
+    `Encode.object [ ( "foo", Encode.string value.foo )]`,
   ],
   [
     "interface foo<P> {foo: P}",
     "foo<number>",
-    new Map([["foo", "type alias Foo p = { foo : p }"]]),
-    "Foo Float",
+    `Encode.object [ ( "foo", Encode.float value.foo )]`,
   ],
   [
     "interface foo<P> {foo: P}",
     "foo<number>[]",
-    new Map([["foo", "type alias Foo p = { foo : p }"]]),
-    "List (Foo Float)",
+    `Encode.list (\\el -> Encode.object [ ( "foo", Encode.float el.foo )]) value`,
   ],
   [
     `type Foo = "bar" | "baz"`,
     "Foo",
-    new Map([["Foo", "type Foo = Bar | Baz"]]),
-    "Foo",
+    `case (value) of
+        Bar -> Encode.string "bar"
+        Baz -> Encode.string "baz"`,
   ],
   [
     `type Foo = "bar" | { tag: "baz", value: number }`,
     "Foo",
-    new Map([["Foo", "type Foo = Bar | Baz ({ value : Float })"]]),
-    "Foo",
+    `case (value) of
+        Bar -> Encode.string "bar"
+        Baz baz -> Encode.object [ ( "tag", Encode.string "baz" )
+    , ( "value", Encode.float baz.value )]`,
   ],
   [
     `type Foo = { tag: 'foo', value: number } & { name : string }`,
     "Foo",
-    new Map(),
-    "{ tag : String, value : Float, name : String }",
+    `Encode.object [ ( "tag", Encode.string "foo" )
+    , ( "value", Encode.float value.value )
+    , ( "name", Encode.string value.name )]`,
   ],
-])("%s type %s converts", (tsTypeDef, tsTypeRef, elmTypeDef, elmTypeRef) => {
+])("%s type %s converts", (tsTypeDef, tsTypeRef, elmTypeRef) => {
   test("converts types correctly", () => {
     const source = `
     ${tsTypeDef};
@@ -116,10 +120,9 @@ describe.each([
       const type = checker.getTypeAtLocation(
         (stmt as ts.VariableDeclaration).type!
       );
-      const elmType = buildType(type, checker, stmt);
-      expect(elmType.expression).toEqual(elmTypeRef);
-      expect(elmType.definitions).toEqual(elmTypeDef);
+      const elmType = buildEncoder(type, "value", checker, new Map());
+      expect(elmType).toEqual(elmTypeRef);
     });
-    expect.assertions(2);
+    expect.assertions(1);
   });
 });

--- a/src/elm/encoder.ts
+++ b/src/elm/encoder.ts
@@ -1,5 +1,5 @@
 import * as ts from "typescript";
-import { toValueCase, toTypeCase, introduce } from "./utils";
+import { toValueCase, toTypeCase, introduce, enumInfo, tupleElements } from "./utils";
 import { TransformError, nodeFromType } from "../error";
 
 const todo = (name: string) => {
@@ -28,6 +28,25 @@ export const buildEncoder = (
   const error = (message: string): never => {
     throw new TransformError(nodeFromType(type), message);
   };
+
+  // Enums (a union of EnumLiteral members) encode as a `case` mapping each Elm
+  // constructor to its serialized value: a string for string enums, the ordinal
+  // for numeric enums.
+  const enumType = enumInfo(type, checker);
+  if (enumType) {
+    return `case (${value}) of
+${enumType.members
+  .map(
+    (member) =>
+      `${branchIndent}${member.constructor} -> ${
+        enumType.isString
+          ? `Encode.string "${member.value}"`
+          : `Encode.int ${member.value}`
+      }`
+  )
+  .join("\n")}`;
+  }
+
   switch (type.flags) {
     case ts.TypeFlags.Any:
       error("Any type is not supported: its shape is unknown so no encoder can be generated");
@@ -42,8 +61,7 @@ export const buildEncoder = (
     case ts.TypeFlags.Boolean:
     case ts.TypeFlags.Boolean | ts.TypeFlags.Union:
       return `Encode.bool ${value}`;
-    case ts.TypeFlags.Enum:
-      return todo("Enum");
+    // Enums are handled by the enumInfo guard above.
 
     case ts.TypeFlags.BigInt:
     case ts.TypeFlags.BigIntLiteral:
@@ -81,6 +99,30 @@ export const buildEncoder = (
           newScope,
           indent + INDENT_STEP
         )}) ${value}`;
+      }
+
+      // Tuples encode as a positional JSON array. We destructure with an
+      // immediately-applied lambda (no `case`, so it parses at any nesting depth).
+      const tupleTypes = tupleElements(type, checker);
+      if (tupleTypes) {
+        if (tupleTypes.length < 2 || tupleTypes.length > 3) {
+          error(
+            `Tuples with ${tupleTypes.length} elements are not supported; Elm only has 2- and 3-element tuples`
+          );
+        }
+        let tupleScope = scope;
+        const names = tupleTypes.map((_, i) => {
+          let name;
+          [name, tupleScope] = introduce(`t${i}`, tupleScope);
+          return name;
+        });
+        const encoded = tupleTypes
+          .map(
+            (el, i) =>
+              buildEncoder(el, names[i], checker, tupleScope, indent + INDENT_STEP)
+          )
+          .join(", ");
+        return `(\\( ${names.join(", ")} ) -> Encode.list identity [ ${encoded} ]) ${value}`;
       }
 
       const stringIndexType = checker.getIndexTypeOfType(

--- a/src/elm/encoder.ts
+++ b/src/elm/encoder.ts
@@ -1,5 +1,14 @@
 import * as ts from "typescript";
-import { toValueCase, toTypeCase, introduce, enumInfo, tupleElements } from "./utils";
+import {
+  toValueCase,
+  toTypeCase,
+  introduce,
+  enumInfo,
+  tupleElements,
+  templateLiteralInfo,
+  propertyTypeNode,
+  isElmInt,
+} from "./utils";
 import { TransformError, nodeFromType } from "../error";
 
 const todo = (name: string) => {
@@ -21,13 +30,30 @@ export const buildEncoder = (
   value: string,
   checker: ts.TypeChecker,
   scope: Map<string, number>,
-  indent = 8
+  indent = 8,
+  node?: ts.Node
 ): string => {
   let variable, newScope;
   const branchIndent = " ".repeat(indent);
   const error = (message: string): never => {
-    throw new TransformError(nodeFromType(type), message);
+    throw new TransformError(node ?? nodeFromType(type), message);
   };
+
+  // The branded `Int` type presents as an intersection, so it must be handled
+  // before the Intersection→object case that would treat it as a record.
+  if (isElmInt(type, checker)) {
+    return `Encode.int ${value}`;
+  }
+
+  // A template literal type is an opaque newtype wrapping a String, so it
+  // encodes by unwrapping the constructor and encoding the raw string.
+  const templateLiteral = templateLiteralInfo(type, checker, node);
+  if (templateLiteral) {
+    if (!templateLiteral.supported) {
+      return error(templateLiteral.reason);
+    }
+    return `(\\(${templateLiteral.name} raw) -> Encode.string raw) ${value}`;
+  }
 
   // Enums (a union of EnumLiteral members) encode as a `case` mapping each Elm
   // constructor to its serialized value: a string for string enums, the ordinal
@@ -38,7 +64,7 @@ export const buildEncoder = (
 ${enumType.members
   .map(
     (member) =>
-      `${branchIndent}${member.constructor} -> ${
+      `${branchIndent}${member.ctor} -> ${
         enumType.isString
           ? `Encode.string "${member.value}"`
           : `Encode.int ${member.value}`
@@ -149,7 +175,8 @@ ${enumType.members
               `${value}.${toValueCase(prop.getName())}`,
               checker,
               scope,
-              indent
+              indent,
+              propertyTypeNode(prop)
             )} )`
         )
         .join(" , ")} ]`;
@@ -222,7 +249,8 @@ ${branchIndent}${refType.types
               `${value}.${toValueCase(prop.getName())}`,
               checker,
               scope,
-              indent
+              indent,
+              propertyTypeNode(prop)
             )} )`
         )
         .join(" , ")} ]`;

--- a/src/elm/encoder.ts
+++ b/src/elm/encoder.ts
@@ -7,7 +7,7 @@ import {
   tupleElements,
   templateLiteralInfo,
   propertyTypeNode,
-  isElmInt,
+  customTypeInfo,
 } from "./utils";
 import { TransformError, nodeFromType } from "../error";
 
@@ -39,10 +39,17 @@ export const buildEncoder = (
     throw new TransformError(node ?? nodeFromType(type), message);
   };
 
-  // The branded `Int` type presents as an intersection, so it must be handled
-  // before the Intersection→object case that would treat it as a record.
-  if (isElmInt(type, checker)) {
-    return `Encode.int ${value}`;
+  // A user-defined `ElmType<...>` brand (including the built-in `Int`) supplies
+  // its own encoder function, which we apply to the value. Detected before the
+  // Intersection→object case that would otherwise treat it as a record.
+  const customType = customTypeInfo(type, checker);
+  if (customType) {
+    if (!customType.encoder) {
+      error(
+        `The Elm type "${customType.typeName}" has no encoder, so it cannot be used as an outbound (property) value. Add the encoder argument to its ElmType<...> definition.`
+      );
+    }
+    return `(${customType.encoder}) ${value}`;
   }
 
   // A template literal type is an opaque newtype wrapping a String, so it

--- a/src/elm/encoder.ts
+++ b/src/elm/encoder.ts
@@ -1,5 +1,5 @@
 import * as ts from "typescript";
-import { toValueCase } from "./utils";
+import { toValueCase, toTypeCase, introduce } from "./utils";
 
 const todo = (name: string) => {
   console.warn(`${name} is not implemented for encoders`);
@@ -9,8 +9,10 @@ const todo = (name: string) => {
 export const buildEncoder = (
   type: ts.Type,
   value: string,
-  checker: ts.TypeChecker
+  checker: ts.TypeChecker,
+  scope: Map<string, number>
 ): string => {
+  let variable, newScope;
   switch (type.flags) {
     case ts.TypeFlags.Any:
       throw new Error("Any type not supported");
@@ -32,12 +34,10 @@ export const buildEncoder = (
     case ts.TypeFlags.BigIntLiteral:
       throw new Error("BigInt type not supported");
     case ts.TypeFlags.StringLiteral:
-      // TODO: Implement string encoder
-      return `Encode.string ${value}`;
+      return `Encode.string "${type.isStringLiteral() && type.value}"`;
 
     case ts.TypeFlags.NumberLiteral:
-      // TODO: Implement NumberLiteral
-      return `Encode.float ${value}`;
+      return `Encode.float ${type.isNumberLiteral() && type.value}`;
 
     case ts.TypeFlags.BooleanLiteral:
       // TODO: Implement BooleanLiteral
@@ -57,10 +57,13 @@ export const buildEncoder = (
       return todo("TypeParameter");
     case ts.TypeFlags.Object:
       if (checker.isArrayType(type)) {
-        return `Encode.list (\\el -> ${buildEncoder(
+        [variable, newScope] = introduce("el", scope);
+        console.log("variable", variable, newScope);
+        return `Encode.list (\\${variable} -> ${buildEncoder(
           checker.getTypeArguments(type as ts.TypeReference)[0],
-          "el",
-          checker
+          variable,
+          checker,
+          newScope
         )}) ${value}`;
       }
 
@@ -71,17 +74,58 @@ export const buildEncoder = (
             `( "${prop.getName()}", ${buildEncoder(
               checker.getTypeOfSymbol(prop),
               `${value}.${toValueCase(prop.getName())}`,
-              checker
+              checker,
+              scope
             )} )`
         )
         .join("\n    , ")}]`;
 
     case ts.TypeFlags.Union:
-      return todo("Union");
+      let refType = checker.getDeclaredTypeOfSymbol(
+        type.aliasSymbol
+      ) as ts.UnionType;
+      return `case (${value}) of
+        ${refType.types
+          .map((t) => {
+            if (t.isStringLiteral()) {
+              return `${toTypeCase(t.value)} -> ${buildEncoder(
+                t,
+                value,
+                checker,
+                scope
+              )}`;
+            } else {
+              let prop = t
+                .getProperties()
+                .map((sym) =>
+                  checker.getTypeOfSymbolAtLocation(sym, sym.valueDeclaration)
+                )
+                .find((ts) => ts.isStringLiteral())?.value;
+              [variable, newScope] = introduce(toValueCase(prop), scope);
 
-    // case ts.TypeFlags.Intersection:
-    //   // TODO: ???
-    //   return `Debug.todo`;
+              return `${toTypeCase(prop)} ${variable} -> ${buildEncoder(
+                t,
+                variable,
+                checker,
+                newScope
+              )}`;
+            }
+          })
+          .join("\n        ")}`;
+
+    case ts.TypeFlags.Intersection:
+      return `Encode.object [ ${checker
+        .getPropertiesOfType(type)
+        .map(
+          (prop) =>
+            `( "${prop.getName()}", ${buildEncoder(
+              checker.getTypeOfSymbol(prop),
+              `${value}.${toValueCase(prop.getName())}`,
+              checker,
+              scope
+            )} )`
+        )
+        .join("\n    , ")}]`;
 
     // case ts.TypeFlags.Index:
     //   // TODO: ???

--- a/src/elm/encoder.ts
+++ b/src/elm/encoder.ts
@@ -59,7 +59,6 @@ export const buildEncoder = (
     case ts.TypeFlags.Object:
       if (checker.isArrayType(type)) {
         [variable, newScope] = introduce("el", scope);
-        console.log("variable", variable, newScope);
         return `Encode.list (\\${variable} -> ${buildEncoder(
           checker.getTypeArguments(type as ts.TypeReference)[0],
           variable,
@@ -94,7 +93,10 @@ export const buildEncoder = (
         const subtype = refType.types.find(
           (t) => t.flags !== ts.TypeFlags.Undefined
         );
-        [variable, newScope] = introduce(subtype.symbol?.name ?? "val", scope);
+        [variable, newScope] = introduce(
+          toValueCase(subtype.symbol?.name ?? "val"),
+          scope
+        );
         return `case (${value}) of
     Nothing -> Encode.null
     Just ${variable} -> ${buildEncoder(subtype, variable, checker, newScope)}

--- a/src/elm/encoder.ts
+++ b/src/elm/encoder.ts
@@ -69,7 +69,7 @@ export const buildEncoder = (
         .map(
           (prop) =>
             `( "${prop.getName()}", ${buildEncoder(
-              checker.getTypeAtLocation(prop.valueDeclaration),
+              checker.getTypeOfSymbol(prop),
               `${value}.${toValueCase(prop.getName())}`,
               checker
             )} )`

--- a/src/elm/encoder.ts
+++ b/src/elm/encoder.ts
@@ -1,24 +1,39 @@
 import * as ts from "typescript";
 import { toValueCase, toTypeCase, introduce } from "./utils";
+import { TransformError, nodeFromType } from "../error";
 
 const todo = (name: string) => {
   console.warn(`${name} is not implemented for encoders`);
   return `Debug.todo "${name} is not implemented for encoders"`;
 };
 
+// Elm's layout parser is whitespace-sensitive: the only construct we emit that
+// *requires* line breaks is `case`, whose branches must be indented strictly
+// deeper than any enclosing branch. We thread `indent` (the column of this
+// expression's case branches) through the recursion and bump it by `INDENT_STEP`
+// whenever we descend into a case branch body, so arbitrarily nested unions stay
+// well-indented. Everything else is emitted on a single line, which parses at any
+// depth. `elm-format` reprints the result, so we only need it to parse.
+const INDENT_STEP = 4;
+
 export const buildEncoder = (
   type: ts.Type,
   value: string,
   checker: ts.TypeChecker,
-  scope: Map<string, number>
+  scope: Map<string, number>,
+  indent = 8
 ): string => {
   let variable, newScope;
+  const branchIndent = " ".repeat(indent);
+  const error = (message: string): never => {
+    throw new TransformError(nodeFromType(type), message);
+  };
   switch (type.flags) {
     case ts.TypeFlags.Any:
-      throw new Error("Any type not supported");
+      error("Any type is not supported: its shape is unknown so no encoder can be generated");
     case ts.TypeFlags.Unknown:
-      throw new Error(
-        "The type was Unknown, but we need to know the type to infer an encoder"
+      error(
+        "Unknown type is not supported: its shape is unknown so no encoder can be generated"
       );
     case ts.TypeFlags.String:
       return `Encode.string ${value}`;
@@ -32,7 +47,7 @@ export const buildEncoder = (
 
     case ts.TypeFlags.BigInt:
     case ts.TypeFlags.BigIntLiteral:
-      throw new Error("BigInt type not supported");
+      error("BigInt type is not supported: Elm has no BigInt equivalent");
     case ts.TypeFlags.StringLiteral:
       return `Encode.string "${type.isStringLiteral() && type.value}"`;
 
@@ -45,14 +60,14 @@ export const buildEncoder = (
 
     case ts.TypeFlags.ESSymbol:
     case ts.TypeFlags.UniqueESSymbol:
-      throw new Error("Any type not supported");
+      error("Symbol type is not supported: symbols cannot be serialized to JSON");
 
     case ts.TypeFlags.Void:
     case ts.TypeFlags.Undefined:
     case ts.TypeFlags.Null:
       return `Encode.null`;
     case ts.TypeFlags.Never:
-      throw new Error("Emtpy/void types not supported");
+      error("Never type is not supported: it has no runtime representation");
 
     case ts.TypeFlags.TypeParameter:
       return todo("TypeParameter");
@@ -63,7 +78,23 @@ export const buildEncoder = (
           checker.getTypeArguments(type as ts.TypeReference)[0],
           variable,
           checker,
-          newScope
+          newScope,
+          indent + INDENT_STEP
+        )}) ${value}`;
+      }
+
+      const stringIndexType = checker.getIndexTypeOfType(
+        type,
+        ts.IndexKind.String
+      );
+      if (stringIndexType && checker.getPropertiesOfType(type).length === 0) {
+        [variable, newScope] = introduce("v", scope);
+        return `Encode.dict identity (\\${variable} -> ${buildEncoder(
+          stringIndexType,
+          variable,
+          checker,
+          newScope,
+          indent + INDENT_STEP
         )}) ${value}`;
       }
 
@@ -75,10 +106,11 @@ export const buildEncoder = (
               checker.getTypeOfSymbol(prop),
               `${value}.${toValueCase(prop.getName())}`,
               checker,
-              scope
+              scope,
+              indent
             )} )`
         )
-        .join("\n    , ")}]`;
+        .join(" , ")} ]`;
 
     case ts.TypeFlags.Union:
       let refType = (
@@ -98,38 +130,45 @@ export const buildEncoder = (
           scope
         );
         return `case (${value}) of
-    Nothing -> Encode.null
-    Just ${variable} -> ${buildEncoder(subtype, variable, checker, newScope)}
-`;
+${branchIndent}Nothing -> Encode.null
+${branchIndent}Just ${variable} -> ${buildEncoder(
+          subtype,
+          variable,
+          checker,
+          newScope,
+          indent + INDENT_STEP
+        )}`;
       }
       return `case (${value}) of
-        ${refType.types
-          .map((t) => {
-            if (t.isStringLiteral()) {
-              return `${toTypeCase(t.value)} -> ${buildEncoder(
-                t,
-                value,
-                checker,
-                scope
-              )}`;
-            } else {
-              let prop = t
-                .getProperties()
-                .map((sym) =>
-                  checker.getTypeOfSymbolAtLocation(sym, sym.valueDeclaration)
-                )
-                .find((ts) => ts.isStringLiteral())?.value;
-              [variable, newScope] = introduce(toValueCase(prop), scope);
+${branchIndent}${refType.types
+        .map((t) => {
+          if (t.isStringLiteral()) {
+            return `${toTypeCase(t.value)} -> ${buildEncoder(
+              t,
+              value,
+              checker,
+              scope,
+              indent + INDENT_STEP
+            )}`;
+          } else {
+            let prop = t
+              .getProperties()
+              .map((sym) =>
+                checker.getTypeOfSymbolAtLocation(sym, sym.valueDeclaration)
+              )
+              .find((ts) => ts.isStringLiteral())?.value;
+            [variable, newScope] = introduce(toValueCase(prop), scope);
 
-              return `${toTypeCase(prop)} ${variable} -> ${buildEncoder(
-                t,
-                variable,
-                checker,
-                newScope
-              )}`;
-            }
-          })
-          .join("\n        ")}`;
+            return `${toTypeCase(prop)} ${variable} -> ${buildEncoder(
+              t,
+              variable,
+              checker,
+              newScope,
+              indent + INDENT_STEP
+            )}`;
+          }
+        })
+        .join("\n" + branchIndent)}`;
 
     case ts.TypeFlags.Intersection:
       return `Encode.object [ ${checker
@@ -140,10 +179,11 @@ export const buildEncoder = (
               checker.getTypeOfSymbol(prop),
               `${value}.${toValueCase(prop.getName())}`,
               checker,
-              scope
+              scope,
+              indent
             )} )`
         )
-        .join("\n    , ")}]`;
+        .join(" , ")} ]`;
 
     // case ts.TypeFlags.Index:
     //   // TODO: ???
@@ -177,6 +217,10 @@ export const buildEncoder = (
     //   return `Debug.todo`;
 
     default:
-      throw new Error("Advanced types not supported");
+      return error(
+        `Advanced types not supported (${
+          type.flags
+        }): ${checker.typeToString(type)}`
+      );
   }
 };

--- a/src/elm/encoder.ts
+++ b/src/elm/encoder.ts
@@ -50,6 +50,7 @@ export const buildEncoder = (
     case ts.TypeFlags.Void:
     case ts.TypeFlags.Undefined:
     case ts.TypeFlags.Null:
+      return `Encode.null`;
     case ts.TypeFlags.Never:
       throw new Error("Emtpy/void types not supported");
 
@@ -81,9 +82,24 @@ export const buildEncoder = (
         .join("\n    , ")}]`;
 
     case ts.TypeFlags.Union:
-      let refType = checker.getDeclaredTypeOfSymbol(
+      let refType = (
         type.aliasSymbol
+          ? checker.getDeclaredTypeOfSymbol(type.aliasSymbol)
+          : type
       ) as ts.UnionType;
+      if (
+        refType.types.length === 2 &&
+        refType.types.some((t) => t.flags === ts.TypeFlags.Undefined)
+      ) {
+        const subtype = refType.types.find(
+          (t) => t.flags !== ts.TypeFlags.Undefined
+        );
+        [variable, newScope] = introduce(subtype.symbol?.name ?? "val", scope);
+        return `case (${value}) of
+    Nothing -> Encode.null
+    Just ${variable} -> ${buildEncoder(subtype, variable, checker, newScope)}
+`;
+      }
       return `case (${value}) of
         ${refType.types
           .map((t) => {

--- a/src/elm/error.test.ts
+++ b/src/elm/error.test.ts
@@ -103,3 +103,18 @@ describe("tuples beyond Elm's arity", () => {
     });
   });
 });
+
+describe("anonymous template literals", () => {
+  test("an inline template literal (no named alias) is rejected", () => {
+    expect.assertions(1);
+    // Inline `${...}` types have no name to give the opaque Elm newtype, so
+    // even with the reference node they cannot be supported.
+    withType("`item-${string}`", (type, checker, node) => {
+      try {
+        buildType(type, checker, node);
+      } catch (e) {
+        expect(e).toBeInstanceOf(TransformError);
+      }
+    });
+  });
+});

--- a/src/elm/error.test.ts
+++ b/src/elm/error.test.ts
@@ -1,0 +1,70 @@
+import { buildType } from "./type";
+import { buildEncoder } from "./encoder";
+import { buildDecoder } from "./decoder";
+import { TransformError } from "../error";
+import * as ts from "typescript";
+import { query } from "@phenomnomnominal/tsquery";
+
+const withType = (tsType: string, fn: (type: ts.Type, checker: ts.TypeChecker, node: ts.Node) => void) => {
+  const source = `
+    let target : ${tsType};
+    `;
+  const host = ts.createCompilerHost({});
+  const orig = host.getSourceFile;
+  host.getSourceFile = (fileName, ...args) => {
+    if (fileName == "input.ts") {
+      return ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest);
+    }
+    return orig(fileName, ...args);
+  };
+
+  const program = ts.createProgram(["input.ts"], { strictNullChecks: true }, host);
+  const checker = program.getTypeChecker();
+  const ast = program.getSourceFile("input.ts")!;
+  query(ast, "VariableDeclaration").forEach((stmt) => {
+    const type = checker.getTypeAtLocation(
+      (stmt as ts.VariableDeclaration).type!
+    );
+    fn(type, checker, stmt);
+  });
+};
+
+describe.each([
+  ["bigint", "BigInt"],
+  ["symbol", "Symbol"],
+])("unsupported type %s", (tsType, label) => {
+  test("buildType throws a located TransformError", () => {
+    expect.assertions(2);
+    withType(tsType, (type, checker, node) => {
+      try {
+        buildType(type, checker, node);
+      } catch (e) {
+        expect(e).toBeInstanceOf(TransformError);
+        // diagnostic string carries the source location context
+        expect((e as TransformError).diagnostic.toString()).toContain("input.ts");
+      }
+    });
+  });
+
+  test("buildEncoder throws a TransformError", () => {
+    expect.assertions(1);
+    withType(tsType, (type, checker) => {
+      try {
+        buildEncoder(type, "value", checker, new Map());
+      } catch (e) {
+        expect(e).toBeInstanceOf(TransformError);
+      }
+    });
+  });
+
+  test("buildDecoder throws a TransformError", () => {
+    expect.assertions(1);
+    withType(tsType, (type, checker) => {
+      try {
+        buildDecoder(type, checker, new Map());
+      } catch (e) {
+        expect(e).toBeInstanceOf(TransformError);
+      }
+    });
+  });
+});

--- a/src/elm/error.test.ts
+++ b/src/elm/error.test.ts
@@ -118,3 +118,62 @@ describe("anonymous template literals", () => {
     });
   });
 });
+
+describe("custom ElmType used in an unsupported direction", () => {
+  const ELM_TYPE_DEF = `type ElmType<Base, Name extends string, Dec extends string = "", Enc extends string = "", Mods extends readonly string[] = []> =
+  Base & { readonly __elmType__: Name; readonly __elmDecoder__: Dec; readonly __elmEncoder__: Enc; readonly __elmModules__: Mods; };`;
+
+  const withCustom = (
+    defs: string,
+    fn: (type: ts.Type, checker: ts.TypeChecker, node: ts.Node) => void
+  ) => {
+    const source = `${ELM_TYPE_DEF}\n${defs}\nlet target : Custom;`;
+    const host = ts.createCompilerHost({});
+    const orig = host.getSourceFile;
+    host.getSourceFile = (fileName, ...args) =>
+      fileName == "input.ts"
+        ? ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest)
+        : orig(fileName, ...args);
+    const program = ts.createProgram(
+      ["input.ts"],
+      { strictNullChecks: true },
+      host
+    );
+    const checker = program.getTypeChecker();
+    const ast = program.getSourceFile("input.ts")!;
+    query(ast, "VariableDeclaration").forEach((stmt) => {
+      const node = (stmt as ts.VariableDeclaration).type!;
+      fn(checker.getTypeAtLocation(node), checker, node);
+    });
+  };
+
+  test("a decoder-less type cannot be decoded (used in an event)", () => {
+    expect.assertions(1);
+    // Encoder only, no decoder.
+    withCustom(
+      `type Custom = ElmType<string, "Foo", "", "myEnc">;`,
+      (type, checker) => {
+        try {
+          buildDecoder(type, checker, new Map());
+        } catch (e) {
+          expect(e).toBeInstanceOf(TransformError);
+        }
+      }
+    );
+  });
+
+  test("an encoder-less type cannot be encoded (used in a property)", () => {
+    expect.assertions(1);
+    // Decoder only, no encoder.
+    withCustom(
+      `type Custom = ElmType<string, "Foo", "myDec">;`,
+      (type, checker) => {
+        try {
+          buildEncoder(type, "value", checker, new Map());
+        } catch (e) {
+          expect(e).toBeInstanceOf(TransformError);
+        }
+      }
+    );
+  });
+});

--- a/src/elm/error.test.ts
+++ b/src/elm/error.test.ts
@@ -87,3 +87,19 @@ describe("unsupported type reached through a library type", () => {
     });
   });
 });
+
+describe("tuples beyond Elm's arity", () => {
+  test.each([
+    ["[string, number, boolean, string]", 4],
+    ["[string]", 1],
+  ])("%s is rejected as unsupported", (tsType) => {
+    expect.assertions(1);
+    withType(tsType, (type, checker, node) => {
+      try {
+        buildType(type, checker, node);
+      } catch (e) {
+        expect(e).toBeInstanceOf(TransformError);
+      }
+    });
+  });
+});

--- a/src/elm/error.test.ts
+++ b/src/elm/error.test.ts
@@ -68,3 +68,22 @@ describe.each([
     });
   });
 });
+
+describe("unsupported type reached through a library type", () => {
+  test("blames the usage site, not the library .d.ts declaration", () => {
+    expect.assertions(3);
+    // `Record<string, any>` bottoms out at the unsupported `any`. The offending
+    // declaration of `Record` lives in a lib `.d.ts`, so the error must instead
+    // point at where the type is used, in input.ts.
+    withType("Record<string, any>", (type, checker, node) => {
+      try {
+        buildType(type, checker, node);
+      } catch (e) {
+        expect(e).toBeInstanceOf(TransformError);
+        const diagnostic = (e as TransformError).diagnostic.toString();
+        expect(diagnostic).toContain("input.ts");
+        expect(diagnostic).not.toContain(".d.ts");
+      }
+    });
+  });
+});

--- a/src/elm/type.test.ts
+++ b/src/elm/type.test.ts
@@ -40,9 +40,24 @@ describe.each([
 
 describe.each([
   [
-    "type Foo = {foo: string}",
-    "Foo",
+    "type foo = {foo: string}",
+    "foo",
     new Map([["Foo", "type alias Foo = { foo : String }"]]),
+    "Foo",
+  ],
+  [
+    `/**
+  * Some comment
+  */
+type Foo = {foo: string}`,
+    "Foo",
+    new Map([
+      [
+        "Foo",
+        `{-| Some comment -}
+type alias Foo = { foo : String }`,
+      ],
+    ]),
     "Foo",
   ],
   [
@@ -64,27 +79,33 @@ describe.each([
     "Foo",
   ],
   [
+    "/**\n * Docs\n */\ninterface Foo {foo: string}",
+    "Foo",
+    new Map([["Foo", "{-| Docs -}\ntype alias Foo = { foo : String }"]]),
+    "Foo",
+  ],
+  [
     "interface foo<P> {foo: P}",
     "foo<number>",
-    new Map([["foo", "type alias Foo p = { foo : p }"]]),
+    new Map([["Foo", "type alias Foo p = { foo : p }"]]),
     "Foo Float",
   ],
   [
     "interface foo<P> {foo: P}",
     "foo<number>[]",
-    new Map([["foo", "type alias Foo p = { foo : p }"]]),
+    new Map([["Foo", "type alias Foo p = { foo : p }"]]),
     "List (Foo Float)",
   ],
   [
-    `type Foo = "bar" | "baz"`,
-    "Foo",
-    new Map([["Foo", "type Foo = Bar | Baz"]]),
+    `type foo = "bar" | "baz"`,
+    "foo",
+    new Map([["Foo(..)", "type Foo = Bar | Baz"]]),
     "Foo",
   ],
   [
     `type Foo = "bar" | { tag: "baz", value: number }`,
     "Foo",
-    new Map([["Foo", "type Foo = Bar | Baz ({ value : Float })"]]),
+    new Map([["Foo(..)", "type Foo = Bar | Baz ({ value : Float })"]]),
     "Foo",
   ],
   [

--- a/src/elm/type.test.ts
+++ b/src/elm/type.test.ts
@@ -13,6 +13,9 @@ describe.each([
   ["Record<string, number>", "Dict String (Float)"],
   ["{ [key: string]: string }", "Dict String (String)"],
   ["Record<string, { x: number }>", "Dict String ({ x : Float })"],
+  ["[string, number]", "( String, Float )"],
+  ["[string, number, boolean]", "( String, Float, Bool )"],
+  ["[string, number[]]", "( String, List (Float) )"],
 ])("simple types %s converts to %s", (tsType, elmType) => {
   test("converts types correctly", () => {
     const source = `
@@ -116,6 +119,18 @@ type alias Foo = { foo : String }`,
     "Foo",
     new Map(),
     "{ tag : String, value : Float, name : String }",
+  ],
+  [
+    `enum Foo { Red = "red", Green = "green" }`,
+    "Foo",
+    new Map([["Foo(..)", "type Foo = Red | Green"]]),
+    "Foo",
+  ],
+  [
+    `enum Foo { Red, Green, Blue }`,
+    "Foo",
+    new Map([["Foo(..)", "type Foo = Red | Green | Blue"]]),
+    "Foo",
   ],
 ])("%s type %s converts", (tsTypeDef, tsTypeRef, elmTypeDef, elmTypeRef) => {
   test("converts types correctly", () => {

--- a/src/elm/type.test.ts
+++ b/src/elm/type.test.ts
@@ -1,5 +1,6 @@
 import { buildType } from "./type";
 import * as ts from "typescript";
+import { query } from "@phenomnomnominal/tsquery";
 
 describe.each([
   ["string", "String"],
@@ -12,7 +13,7 @@ describe.each([
 ])("simple types %s converts to %s", (tsType, elmType) => {
   test("converts types correctly", () => {
     const source = `
-    type Target = ${tsType};
+    let target : ${tsType};
     `;
     const host = ts.createCompilerHost({});
     const orig = host.getSourceFile;
@@ -26,9 +27,69 @@ describe.each([
     const program = ts.createProgram(["input.ts"], {}, host);
     const checker = program.getTypeChecker();
     const ast = program.getSourceFile("input.ts")!;
-    const type = checker.getTypeAtLocation(
-      (ast.statements[0] as ts.TypeAliasDeclaration).type
-    );
-    expect(buildType(type, checker)).toEqual(elmType);
+    query(ast, "VariableDeclaration").forEach((stmt) => {
+      const type = checker.getTypeAtLocation(
+        (stmt as ts.VariableDeclaration).type!
+      );
+
+      expect(buildType(type, checker).expression).toEqual(elmType);
+    });
+    expect.assertions(1);
+  });
+});
+
+describe.only.each([
+  [
+    "type Foo = {foo: string}",
+    "Foo",
+    new Map([["Foo", "type alias Foo = { foo : String }"]]),
+    "Foo",
+  ],
+  [
+    "type Foo<P> = {foo: P}",
+    "Foo<number>",
+    new Map([["Foo", "type alias Foo p = { foo : p }"]]),
+    "Foo Float",
+  ],
+  [
+    "interface Foo {foo: string}",
+    "Foo",
+    new Map([["Foo", "type alias Foo = { foo : String }"]]),
+    "Foo",
+  ],
+  [
+    "interface foo<P> {foo: P}",
+    "foo<number>",
+    new Map([["foo", "type alias Foo p = { foo : p }"]]),
+    "Foo Float",
+  ],
+])("%s type %s converts", (tsTypeDef, tsTypeRef, elmTypeDef, elmTypeRef) => {
+  test("converts types correctly", () => {
+    const source = `
+    ${tsTypeDef};
+
+    let target : ${tsTypeRef};
+    `;
+    const host = ts.createCompilerHost({});
+    const orig = host.getSourceFile;
+    host.getSourceFile = (fileName, ...args) => {
+      if (fileName == "input.ts") {
+        return ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest);
+      }
+      return orig(fileName, ...args);
+    };
+
+    const program = ts.createProgram(["input.ts"], {}, host);
+    const checker = program.getTypeChecker();
+    const ast = program.getSourceFile("input.ts")!;
+    query(ast, "VariableDeclaration").forEach((stmt) => {
+      const type = checker.getTypeAtLocation(
+        (stmt as ts.VariableDeclaration).type!
+      );
+      const elmType = buildType(type, checker);
+      expect(elmType.expression).toEqual(elmTypeRef);
+      expect(elmType.definitions).toEqual(elmTypeDef);
+    });
+    expect.assertions(2);
   });
 });

--- a/src/elm/type.test.ts
+++ b/src/elm/type.test.ts
@@ -45,12 +45,12 @@ describe.each([
     new Map([["Foo", "type alias Foo = { foo : String }"]]),
     "Foo",
   ],
-  // [
-  //   "type Foo = {foo?: string}",
-  //   "Foo",
-  //   new Map([["Foo", "type alias Foo = { foo : Maybe String }"]]),
-  //   "Foo",
-  // ],
+  [
+    "type Foo = {foo?: string}",
+    "Foo",
+    new Map([["Foo", "type alias Foo = { foo : Maybe String }"]]),
+    "Foo",
+  ],
   [
     "type Foo<P> = {foo: P}",
     "Foo<number>",
@@ -109,7 +109,7 @@ describe.each([
       return orig(fileName, ...args);
     };
 
-    const program = ts.createProgram(["input.ts"], {}, host);
+    const program = ts.createProgram(["input.ts"], { strict: true }, host);
     const checker = program.getTypeChecker();
     const ast = program.getSourceFile("input.ts")!;
     query(ast, "VariableDeclaration").forEach((stmt) => {

--- a/src/elm/type.test.ts
+++ b/src/elm/type.test.ts
@@ -133,13 +133,15 @@ type alias Foo = { foo : String }`,
     "Foo",
   ],
   [
-    `type Int = number & { readonly __elmInt__?: never }`,
+    `type ElmType<Base, Name extends string, Dec extends string = "", Enc extends string = "", Mods extends readonly string[] = []> = Base & { readonly __elmType__: Name; readonly __elmDecoder__: Dec; readonly __elmEncoder__: Enc; readonly __elmModules__: Mods; };
+     type Int = ElmType<number, "Int", "Decode.int", "Encode.int">`,
     "Int",
     new Map(),
     "Int",
   ],
   [
-    `type Int = number & { readonly __elmInt__?: never };
+    `type ElmType<Base, Name extends string, Dec extends string = "", Enc extends string = "", Mods extends readonly string[] = []> = Base & { readonly __elmType__: Name; readonly __elmDecoder__: Dec; readonly __elmEncoder__: Enc; readonly __elmModules__: Mods; };
+     type Int = ElmType<number, "Int", "Decode.int", "Encode.int">;
      type Point = { x: Int; y: number }`,
     "Point",
     new Map([["Point", "type alias Point = { x : Int, y : Float }"]]),
@@ -258,6 +260,40 @@ describe("nested template literal", () => {
       // the record references the opaque Size, and its definitions are carried up
       expect(elmType.definitions.get("Size")).toEqual("type Size\n    = Size String");
       expect(elmType.definitions.has("size")).toBe(true);
+    });
+    expect.assertions(2);
+  });
+});
+
+// A user-defined ElmType<...> brand maps to an arbitrary Elm type and carries
+// its required module imports, structurally (so it also works nested in records).
+const ELM_TYPE_DEF = `type ElmType<Base, Name extends string, Dec extends string = "", Enc extends string = "", Mods extends readonly string[] = []> =
+  Base & { readonly __elmType__: Name; readonly __elmDecoder__: Dec; readonly __elmEncoder__: Enc; readonly __elmModules__: Mods; };
+type Posix = ElmType<number, "Time.Posix", "Decode.map Time.millisToPosix Decode.int", "\\\\p -> Encode.int (Time.posixToMillis p)", ["Time"]>;`;
+
+describe("custom ElmType brand", () => {
+  test.each([
+    ["Posix", "Time.Posix"],
+    ["Posix[]", "List (Time.Posix)"],
+    ["{ at: Posix }", "{ at : Time.Posix }"],
+  ])("%s maps to %s and carries imports", (tsTypeRef, elmTypeRef) => {
+    const source = `${ELM_TYPE_DEF}\n\nlet target : ${tsTypeRef};`;
+    const host = ts.createCompilerHost({});
+    const orig = host.getSourceFile;
+    host.getSourceFile = (fileName, ...args) => {
+      if (fileName == "input.ts") {
+        return ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest);
+      }
+      return orig(fileName, ...args);
+    };
+    const program = ts.createProgram(["input.ts"], { strict: true }, host);
+    const checker = program.getTypeChecker();
+    const ast = program.getSourceFile("input.ts")!;
+    query(ast, "VariableDeclaration").forEach((stmt) => {
+      const node = (stmt as ts.VariableDeclaration).type!;
+      const elmType = buildType(checker.getTypeAtLocation(node), checker, node);
+      expect(elmType.expression).toEqual(elmTypeRef);
+      expect(elmType.imports).toEqual(["import Time"]);
     });
     expect.assertions(2);
   });

--- a/src/elm/type.test.ts
+++ b/src/elm/type.test.ts
@@ -132,6 +132,19 @@ type alias Foo = { foo : String }`,
     new Map([["Foo(..)", "type Foo = Red | Green | Blue"]]),
     "Foo",
   ],
+  [
+    `type Int = number & { readonly __elmInt__?: never }`,
+    "Int",
+    new Map(),
+    "Int",
+  ],
+  [
+    `type Int = number & { readonly __elmInt__?: never };
+     type Point = { x: Int; y: number }`,
+    "Point",
+    new Map([["Point", "type alias Point = { x : Int, y : Float }"]]),
+    "Point",
+  ],
 ])("%s type %s converts", (tsTypeDef, tsTypeRef, elmTypeDef, elmTypeRef) => {
   test("converts types correctly", () => {
     const source = `
@@ -158,6 +171,93 @@ type alias Foo = { foo : String }`,
       const elmType = buildType(type, checker, stmt);
       expect(elmType.expression).toEqual(elmTypeRef);
       expect(elmType.definitions).toEqual(elmTypeDef);
+    });
+    expect.assertions(2);
+  });
+});
+
+// Template literals need the *reference* node (the `Foo` in `let x: Foo`) to
+// recover the alias name, since TypeScript resolves the alias away.
+describe.each([
+  [
+    "type Foo = `item-${string}`",
+    "Foo",
+    "Foo",
+    'type Foo\n    = Foo String',
+  ],
+  [
+    "type Foo = `${number}px`",
+    "Foo",
+    "Foo",
+    "type Foo\n    = Foo String",
+  ],
+])("template literal %s", (tsTypeDef, tsTypeRef, elmTypeRef, elmTypeDef) => {
+  test("converts to an opaque newtype", () => {
+    const source = `
+    ${tsTypeDef};
+
+    let target : ${tsTypeRef};
+    `;
+    const host = ts.createCompilerHost({});
+    const orig = host.getSourceFile;
+    host.getSourceFile = (fileName, ...args) => {
+      if (fileName == "input.ts") {
+        return ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest);
+      }
+      return orig(fileName, ...args);
+    };
+
+    const program = ts.createProgram(["input.ts"], { strict: true }, host);
+    const checker = program.getTypeChecker();
+    const ast = program.getSourceFile("input.ts")!;
+    query(ast, "VariableDeclaration").forEach((stmt) => {
+      const node = (stmt as ts.VariableDeclaration).type!;
+      const type = checker.getTypeAtLocation(node);
+      const elmType = buildType(type, checker, node);
+      expect(elmType.expression).toEqual(elmTypeRef);
+      // the opaque type definition is emitted; a smart constructor accompanies it
+      expect(elmType.definitions.get("Foo")).toEqual(elmTypeDef);
+      expect(elmType.definitions.has("foo")).toBe(true);
+
+      // Inbound (event payload): the opaque newtype would be unusable since its
+      // constructor is not exposed, so it degrades to a plain String.
+      const inbound = buildType(type, checker, node, false, true);
+      expect(inbound.expression).toEqual("String");
+      expect(inbound.definitions.size).toEqual(0);
+    });
+    expect.assertions(5);
+  });
+});
+
+// A template literal nested inside a record must still recover its name from
+// the property's type node (the alias is resolved away on the type itself).
+describe("nested template literal", () => {
+  test("inside a record still becomes an opaque newtype", () => {
+    const source = `
+    type Size = \`\${number}px\`;
+    type Rec = { size: Size };
+
+    let target : Rec;
+    `;
+    const host = ts.createCompilerHost({});
+    const orig = host.getSourceFile;
+    host.getSourceFile = (fileName, ...args) => {
+      if (fileName == "input.ts") {
+        return ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest);
+      }
+      return orig(fileName, ...args);
+    };
+
+    const program = ts.createProgram(["input.ts"], { strict: true }, host);
+    const checker = program.getTypeChecker();
+    const ast = program.getSourceFile("input.ts")!;
+    query(ast, "VariableDeclaration").forEach((stmt) => {
+      const node = (stmt as ts.VariableDeclaration).type!;
+      const type = checker.getTypeAtLocation(node);
+      const elmType = buildType(type, checker, node);
+      // the record references the opaque Size, and its definitions are carried up
+      expect(elmType.definitions.get("Size")).toEqual("type Size\n    = Size String");
+      expect(elmType.definitions.has("size")).toBe(true);
     });
     expect.assertions(2);
   });

--- a/src/elm/type.test.ts
+++ b/src/elm/type.test.ts
@@ -10,6 +10,9 @@ describe.each([
   ["number[]", "List (Float)"],
   ["{foo: number[]}[]", "List ({ foo : List (Float) })"],
   ["{if: string}", "{ if_ : String }"],
+  ["Record<string, number>", "Dict String (Float)"],
+  ["{ [key: string]: string }", "Dict String (String)"],
+  ["Record<string, { x: number }>", "Dict String ({ x : Float })"],
 ])("simple types %s converts to %s", (tsType, elmType) => {
   test("converts types correctly", () => {
     const source = `

--- a/src/elm/type.test.ts
+++ b/src/elm/type.test.ts
@@ -63,7 +63,7 @@ type alias Foo = { foo : String }`,
   [
     "type Foo = {foo?: string}",
     "Foo",
-    new Map([["Foo", "type alias Foo = { foo : Maybe String }"]]),
+    new Map([["Foo", "type alias Foo = { foo : Maybe (String) }"]]),
     "Foo",
   ],
   [

--- a/src/elm/type.ts
+++ b/src/elm/type.ts
@@ -46,16 +46,25 @@ const join = (types: Type[], sep: string): Type => {
 const buildObjectDefinition = (
   type: ts.Type,
   checker: ts.TypeChecker,
-  lastNode: ts.Node
+  lastNode: ts.Node,
+  filterOutLiterals: boolean
 ): Type => {
   return elm`{ ${join(
-    checker.getPropertiesOfType(type).map((prop) => {
-      return elm`${toValueCase(prop.getName())} : ${buildType(
-        checker.getTypeAtLocation(prop.valueDeclaration),
-        checker,
-        lastNode
-      )}`;
-    }),
+    checker
+      .getPropertiesOfType(type)
+      .filter(
+        (prop) =>
+          !filterOutLiterals ||
+          !checker.getTypeAtLocation(prop.valueDeclaration).isStringLiteral()
+      )
+      .map((prop) => {
+        return elm`${toValueCase(prop.getName())} : ${buildType(
+          checker.getTypeAtLocation(prop.valueDeclaration),
+          checker,
+          lastNode,
+          false
+        )}`;
+      }),
     ", "
   )} }`;
 };
@@ -63,7 +72,8 @@ const buildObjectDefinition = (
 export const buildType = (
   type: ts.Type,
   checker: ts.TypeChecker,
-  lastNode: ts.Node
+  lastNode: ts.Node,
+  filterOutLiterals = false
 ): Type => {
   let node;
   if (type.symbol && type.symbol.getDeclarations()?.[0]) {
@@ -132,7 +142,6 @@ export const buildType = (
           node
         )})`;
       }
-
       console.log(
         "target",
         checker.typeToString(type),
@@ -163,7 +172,12 @@ export const buildType = (
               refType.aliasTypeArguments
                 .map((arg): string => toValueCase(arg.symbol.name))
                 .join(" ")
-        } = ${buildObjectDefinition(refType, checker, node)}`;
+        } = ${buildObjectDefinition(
+          refType,
+          checker,
+          node,
+          filterOutLiterals
+        )}`;
 
         let begin = {
           expression: toTypeCase(type.aliasSymbol.name),
@@ -182,7 +196,8 @@ export const buildType = (
           ref = elm`type alias ${type.symbol.name} = ${buildObjectDefinition(
             type,
             checker,
-            node
+            node,
+            filterOutLiterals
           )}`;
           return {
             expression: type.symbol.name,
@@ -205,7 +220,12 @@ export const buildType = (
                 t.target.typeArguments
                   .map((arg): string => toValueCase(arg.symbol.name))
                   .join(" ")
-          } = ${buildObjectDefinition(t.target, checker, node)}`;
+          } = ${buildObjectDefinition(
+            t.target,
+            checker,
+            node,
+            filterOutLiterals
+          )}`;
 
           let begin = {
             expression: toTypeCase(t.symbol.name),
@@ -219,14 +239,56 @@ export const buildType = (
         case ts.ObjectFlags.ArrayLiteral:
           console.log("isArrray");
       }
-      return buildObjectDefinition(type, checker, node);
+      return buildObjectDefinition(type, checker, node, filterOutLiterals);
 
     case ts.TypeFlags.Union:
-      return todo("Union");
+      if (type.aliasSymbol) {
+        let refType = checker.getDeclaredTypeOfSymbol(
+          type.aliasSymbol
+        ) as ts.UnionType;
 
-    // case ts.TypeFlags.Intersection:
-    //   // TODO: ???
-    //   return `Debug.todo`;
+        if (
+          refType.types.every(
+            (t) =>
+              t.isStringLiteral() ||
+              t
+                .getProperties()
+                .some((sym) =>
+                  checker
+                    .getTypeOfSymbolAtLocation(sym, sym.valueDeclaration)
+                    .isStringLiteral()
+                )
+          )
+        ) {
+          let ref = elm`type ${toTypeCase(type.aliasSymbol.name)} = ${join(
+            refType.types.map((t) => {
+              if (t.isStringLiteral()) {
+                return elm`${toTypeCase(t.value)}`;
+              }
+              return elm`${toTypeCase(
+                t
+                  .getProperties()
+                  .map((sym) =>
+                    checker.getTypeOfSymbolAtLocation(sym, sym.valueDeclaration)
+                  )
+                  .find((ts) => ts.isStringLiteral())?.value
+              )} (${buildType(t, checker, node, true)})`;
+            }),
+            " | "
+          )}`;
+          return {
+            expression: toTypeCase(type.aliasSymbol.name),
+            definitions: new Map([
+              [type.aliasSymbol.name, ref.expression],
+              ...ref.definitions,
+            ]),
+          };
+        } else
+          error(`${checker.typeToString(type)} is not a supported Union type`);
+      } else error("Anonymous union types not supported");
+
+    case ts.TypeFlags.Intersection:
+      return buildObjectDefinition(type, checker, node, false);
 
     // case ts.TypeFlags.Index:
     //   // TODO: ???
@@ -260,7 +322,7 @@ export const buildType = (
     //   return `Debug.todo`;
 
     default:
-      throw new Error(
+      error(
         `Advanced types not supported (${type.flags}): ${checker.typeToString(
           type
         )}`

--- a/src/elm/type.ts
+++ b/src/elm/type.ts
@@ -1,6 +1,6 @@
 import * as ts from "typescript";
 import { toTypeCase, toValueCase } from "./utils";
-import { TransformError } from "../error";
+import { TransformError, nodeFromType } from "../error";
 
 export type Type = {
   expression: string;
@@ -90,14 +90,10 @@ export const buildType = (
   lastNode: ts.Node,
   filterOutLiterals = false
 ): Type => {
-  let node: ts.Node;
-  if (type.symbol && type.symbol.getDeclarations()?.[0]) {
-    node = type.symbol.getDeclarations()?.[0]!;
-  } else if (type.aliasSymbol && type.aliasSymbol.getDeclarations()?.[0]) {
-    node = type.aliasSymbol.getDeclarations()?.[0]!;
-  } else {
-    node = lastNode;
-  }
+  // Blame the type's own declaration when it lives in the user's code,
+  // otherwise fall back to the referencing node so errors never point into
+  // library `.d.ts` files (e.g. the definition of `Record` or `Array`).
+  const node = nodeFromType(type, lastNode) ?? lastNode;
 
   const error = (message: string): never => {
     throw new TransformError(node, message);

--- a/src/elm/type.ts
+++ b/src/elm/type.ts
@@ -55,11 +55,11 @@ const buildObjectDefinition = (
       .filter(
         (prop) =>
           !filterOutLiterals ||
-          !checker.getTypeAtLocation(prop.valueDeclaration).isStringLiteral()
+          !checker.getTypeAtLocation(prop.valueDeclaration!).isStringLiteral()
       )
       .map((prop) => {
         return elm`${toValueCase(prop.getName())} : ${buildType(
-          checker.getTypeAtLocation(prop.valueDeclaration),
+          checker.getTypeAtLocation(prop.valueDeclaration!),
           checker,
           lastNode,
           false
@@ -75,11 +75,11 @@ export const buildType = (
   lastNode: ts.Node,
   filterOutLiterals = false
 ): Type => {
-  let node;
+  let node: ts.Node;
   if (type.symbol && type.symbol.getDeclarations()?.[0]) {
-    node = type.symbol.getDeclarations()?.[0];
+    node = type.symbol.getDeclarations()?.[0]!;
   } else if (type.aliasSymbol && type.aliasSymbol.getDeclarations()?.[0]) {
-    node = type.aliasSymbol.getDeclarations()?.[0];
+    node = type.aliasSymbol.getDeclarations()?.[0]!;
   } else {
     node = lastNode;
   }
@@ -255,7 +255,7 @@ export const buildType = (
                 .getProperties()
                 .some((sym) =>
                   checker
-                    .getTypeOfSymbolAtLocation(sym, sym.valueDeclaration)
+                    .getTypeOfSymbolAtLocation(sym, sym.valueDeclaration!)
                     .isStringLiteral()
                 )
           )
@@ -268,10 +268,14 @@ export const buildType = (
               return elm`${toTypeCase(
                 t
                   .getProperties()
-                  .map((sym) =>
-                    checker.getTypeOfSymbolAtLocation(sym, sym.valueDeclaration)
+                  .map(
+                    (sym) =>
+                      checker.getTypeOfSymbolAtLocation(
+                        sym,
+                        sym.valueDeclaration!
+                      )!
                   )
-                  .find((ts) => ts.isStringLiteral())?.value
+                  .find((ts) => ts.isStringLiteral())?.value ?? ""
               )} (${buildType(t, checker, node, true)})`;
             }),
             " | "
@@ -285,7 +289,19 @@ export const buildType = (
           };
         } else
           error(`${checker.typeToString(type)} is not a supported Union type`);
-      } else error("Anonymous union types not supported");
+      } else {
+        let t = type as ts.UnionType;
+        if (
+          t.types.length === 2 &&
+          t.types.some((t) => t.flags === ts.TypeFlags.Undefined)
+        ) {
+          const subtype = t.types.find(
+            (t) => t.flags !== ts.TypeFlags.Undefined
+          );
+          return elm`Maybe ${buildType(subtype!, checker, node)}`;
+        }
+        error("Anonymous union types not supported");
+      }
 
     case ts.TypeFlags.Intersection:
       return buildObjectDefinition(type, checker, node, false);
@@ -323,6 +339,11 @@ export const buildType = (
 
     default:
       error(
+        `Advanced types not supported (${type.flags}): ${checker.typeToString(
+          type
+        )}`
+      );
+      return error(
         `Advanced types not supported (${type.flags}): ${checker.typeToString(
           type
         )}`

--- a/src/elm/type.ts
+++ b/src/elm/type.ts
@@ -69,6 +69,21 @@ const buildObjectDefinition = (
   )} }`;
 };
 
+const buildDocs = (symbol: ts.Symbol, checker: ts.TypeChecker): string => {
+  let docs =
+    symbol
+      ?.getDocumentationComment(checker)
+      .filter((doc) => doc.kind === "text")
+      .map((doc) => doc.text) ?? [];
+
+  let docComment = "";
+
+  if (docs.length > 0) {
+    docComment = `{-| ${docs.join("\n")} -}\n`;
+  }
+  return docComment;
+};
+
 export const buildType = (
   type: ts.Type,
   checker: ts.TypeChecker,
@@ -129,8 +144,9 @@ export const buildType = (
     case ts.TypeFlags.Void:
     case ts.TypeFlags.Undefined:
     case ts.TypeFlags.Null:
-    case ts.TypeFlags.Never:
       error("Emtpy/void types not supported");
+    case ts.TypeFlags.Never:
+      return elm`Never`;
 
     case ts.TypeFlags.TypeParameter:
       return elm`${toValueCase(type.symbol.name)}`;
@@ -142,30 +158,19 @@ export const buildType = (
           node
         )})`;
       }
-      console.log(
-        "target",
-        checker.typeToString(type),
-        (type as ts.ObjectType).objectFlags,
-        type.aliasSymbol
-      );
+
       if (type.aliasSymbol) {
-        // let refType = checker.getSignaturesOfType(type, ts.SignatureKind.);
-        // let refType = checker.getTypeAtLocation(
-        //   (type.aliasSymbol.declarations?.[0] as ts.TypeAliasDeclaration).type!
-        // );
-        console.log(type.aliasSymbol);
         const args =
           type.aliasTypeArguments?.map((arg) =>
             buildType(arg, checker, node)
           ) ?? [];
-        console.log(
-          "declared",
-          checker.getDeclaredTypeOfSymbol(type.aliasSymbol)
-        );
+
         let refType = checker.getDeclaredTypeOfSymbol(type.aliasSymbol);
-        // return;
-        // console.log("refType", refType);
-        let ref = elm`type alias ${toTypeCase(type.aliasSymbol.name)}${
+
+        let ref = elm`${buildDocs(
+          type.aliasSymbol,
+          checker
+        )}type alias ${toTypeCase(type.aliasSymbol.name)}${
           refType.aliasTypeArguments == null
             ? ""
             : " " +
@@ -182,7 +187,7 @@ export const buildType = (
         let begin = {
           expression: toTypeCase(type.aliasSymbol.name),
           definitions: new Map([
-            [type.aliasSymbol.name, ref.expression],
+            [toTypeCase(type.aliasSymbol.name), ref.expression],
             ...ref.definitions.entries(),
           ]),
         };
@@ -193,7 +198,9 @@ export const buildType = (
       let ref;
       switch ((type as ts.ObjectType).objectFlags) {
         case ts.ObjectFlags.Interface:
-          ref = elm`type alias ${type.symbol.name} = ${buildObjectDefinition(
+          ref = elm`${buildDocs(type.symbol, checker)}type alias ${toTypeCase(
+            type.symbol.name
+          )} = ${buildObjectDefinition(
             type,
             checker,
             node,
@@ -202,7 +209,7 @@ export const buildType = (
           return {
             expression: type.symbol.name,
             definitions: new Map([
-              [type.symbol.name, ref.expression],
+              [toTypeCase(type.symbol.name), ref.expression],
               ...ref.definitions,
             ]),
           };
@@ -211,9 +218,10 @@ export const buildType = (
           const args =
             t.typeArguments?.map((arg) => buildType(arg, checker, node)) ?? [];
 
-          console.log(args);
-
-          ref = elm`type alias ${toTypeCase(t.target.symbol.name)}${
+          ref = elm`${buildDocs(
+            t.target.symbol,
+            checker
+          )}type alias ${toTypeCase(t.target.symbol.name)}${
             t.target.typeArguments == null
               ? ""
               : " " +
@@ -230,7 +238,7 @@ export const buildType = (
           let begin = {
             expression: toTypeCase(t.symbol.name),
             definitions: new Map([
-              [t.target.symbol.name, ref.expression],
+              [toTypeCase(t.target.symbol.name), ref.expression],
               ...ref.definitions.entries(),
             ]),
           };
@@ -260,7 +268,10 @@ export const buildType = (
                 )
           )
         ) {
-          let ref = elm`type ${toTypeCase(type.aliasSymbol.name)} = ${join(
+          let ref = elm`${buildDocs(
+            type.aliasSymbol,
+            checker
+          )}type ${toTypeCase(type.aliasSymbol.name)} = ${join(
             refType.types.map((t) => {
               if (t.isStringLiteral()) {
                 return elm`${toTypeCase(t.value)}`;
@@ -283,7 +294,7 @@ export const buildType = (
           return {
             expression: toTypeCase(type.aliasSymbol.name),
             definitions: new Map([
-              [type.aliasSymbol.name, ref.expression],
+              [toTypeCase(type.aliasSymbol.name) + "(..)", ref.expression],
               ...ref.definitions,
             ]),
           };
@@ -298,7 +309,7 @@ export const buildType = (
           const subtype = t.types.find(
             (t) => t.flags !== ts.TypeFlags.Undefined
           );
-          return elm`Maybe ${buildType(subtype!, checker, node)}`;
+          return elm`Maybe (${buildType(subtype!, checker, node)})`;
         }
         error("Anonymous union types not supported");
       }

--- a/src/elm/type.ts
+++ b/src/elm/type.ts
@@ -99,7 +99,7 @@ export const buildType = (
     node = lastNode;
   }
 
-  const error = (message: string) => {
+  const error = (message: string): never => {
     throw new TransformError(node, message);
   };
 
@@ -144,7 +144,7 @@ export const buildType = (
     case ts.TypeFlags.Void:
     case ts.TypeFlags.Undefined:
     case ts.TypeFlags.Null:
-      error("Emtpy/void types not supported");
+      error("Void/undefined/null types are not supported as a type on their own");
     case ts.TypeFlags.Never:
       return elm`Never`;
 
@@ -157,6 +157,17 @@ export const buildType = (
           checker,
           node
         )})`;
+      }
+
+      // A string index signature (`Record<string, X>` or `{ [key: string]: X }`)
+      // maps to an Elm `Dict String X`. We only treat it as a Dict when there are
+      // no named properties, since Elm dictionaries are homogeneous.
+      const stringIndexType = checker.getIndexTypeOfType(
+        type,
+        ts.IndexKind.String
+      );
+      if (stringIndexType && checker.getPropertiesOfType(type).length === 0) {
+        return elm`Dict String (${buildType(stringIndexType, checker, node)})`;
       }
 
       if (type.aliasSymbol) {
@@ -349,11 +360,6 @@ export const buildType = (
     //   return `Debug.todo`;
 
     default:
-      error(
-        `Advanced types not supported (${type.flags}): ${checker.typeToString(
-          type
-        )}`
-      );
       return error(
         `Advanced types not supported (${type.flags}): ${checker.typeToString(
           type

--- a/src/elm/type.ts
+++ b/src/elm/type.ts
@@ -1,91 +1,225 @@
 import * as ts from "typescript";
-import { toValueCase } from "./utils";
+import { toTypeCase, toValueCase } from "./utils";
+import { TransformError } from "../error";
 
-export const buildType = (type: ts.Type, checker: ts.TypeChecker): string => {
-  const todo = (name: string) => {
-    console.warn(
-      `${name} : ${checker.typeToString(type)} is not implemented for types`
-    );
-    throw new Error(`${name} is not implemented for types`);
+export type Type = {
+  expression: string;
+  definitions: Map<string, string>;
+};
+
+const elm = (
+  strings: TemplateStringsArray,
+  ...values: (Type | string)[]
+): Type => {
+  let expression = strings[0];
+  for (let i = 0; i < values.length; i++) {
+    let value = values[i];
+    if (typeof value === "string") {
+      expression += value;
+    } else {
+      expression += value.expression;
+    }
+
+    expression += strings[i + 1];
+  }
+  return {
+    expression,
+    definitions: new Map(
+      values.flatMap((v) =>
+        typeof v == "string" ? [] : Array.from(v.definitions?.entries())
+      )
+    ),
   };
-  // console.log("building type", checker.typeToString(type));
+};
+
+const join = (types: Type[], sep: string): Type => {
+  return elm`${types
+    .map((t, i) => {
+      if (i === 0) {
+        return t;
+      }
+      return elm`${sep}${t}`;
+    })
+    .reduce((acc, t) => elm`${acc}${t}`, elm``)}`;
+};
+
+const buildObjectDefinition = (
+  type: ts.Type,
+  checker: ts.TypeChecker,
+  lastNode: ts.Node
+): Type => {
+  return elm`{ ${join(
+    checker.getPropertiesOfType(type).map((prop) => {
+      return elm`${toValueCase(prop.getName())} : ${buildType(
+        checker.getTypeAtLocation(prop.valueDeclaration),
+        checker,
+        lastNode
+      )}`;
+    }),
+    ", "
+  )} }`;
+};
+
+export const buildType = (
+  type: ts.Type,
+  checker: ts.TypeChecker,
+  lastNode: ts.Node
+): Type => {
+  let node;
+  if (type.symbol && type.symbol.getDeclarations()?.[0]) {
+    node = type.symbol.getDeclarations()?.[0];
+  } else if (type.aliasSymbol && type.aliasSymbol.getDeclarations()?.[0]) {
+    node = type.aliasSymbol.getDeclarations()?.[0];
+  } else {
+    node = lastNode;
+  }
+
+  const error = (message: string) => {
+    throw new TransformError(node, message);
+  };
+
+  const todo = (name: string) => error(`Type ${name} not implemented`);
 
   switch (type.flags) {
     case ts.TypeFlags.Any:
-      throw new Error("Any type not supported");
+      error("Any type not supported");
     case ts.TypeFlags.Unknown:
-      throw new Error(
-        "The type was Unknown, but we need to know the type to infer an encoder"
+      error(
+        "The type was Unknown, but we need to know the type to infer the Elm type"
       );
     case ts.TypeFlags.String:
-      return `String`;
+      return elm`String`;
     case ts.TypeFlags.Number:
-      return `Float`;
+      return elm`Float`;
     case ts.TypeFlags.Boolean:
     case ts.TypeFlags.Boolean | ts.TypeFlags.Union:
-      return `Bool`;
+      return elm`Bool`;
     case ts.TypeFlags.Enum:
       return todo("Enum");
 
     case ts.TypeFlags.BigInt:
     case ts.TypeFlags.BigIntLiteral:
-      throw new Error("BigInt type not supported");
+      error("BigInt type not supported");
     case ts.TypeFlags.StringLiteral:
       // TODO: Implement string encoder
-      return `String`;
+      return elm`String`;
 
     case ts.TypeFlags.NumberLiteral:
       // TODO: Implement NumberLiteral
-      return `Float`;
+      return elm`Float`;
 
     case ts.TypeFlags.BooleanLiteral:
       // TODO: Implement BooleanLiteral
-      return `Bool`;
+      return elm`Bool`;
 
     case ts.TypeFlags.ESSymbol:
     case ts.TypeFlags.UniqueESSymbol:
-      throw new Error("Symbol type not supported");
+      error("Symbol type not supported");
 
     case ts.TypeFlags.Void:
     case ts.TypeFlags.Undefined:
     case ts.TypeFlags.Null:
     case ts.TypeFlags.Never:
-      throw new Error("Emtpy/void types not supported");
+      error("Emtpy/void types not supported");
 
     case ts.TypeFlags.TypeParameter:
-      return todo("TypeParameter");
+      return elm`${toValueCase(type.symbol.name)}`;
     case ts.TypeFlags.Object:
       if (checker.isArrayType(type)) {
-        return `List (${buildType(
+        return elm`List (${buildType(
           checker.getTypeArguments(type as ts.TypeReference)[0],
-          checker
+          checker,
+          node
         )})`;
       }
-      // switch ((type as ts.ObjectType).objectFlags) {
-      //   case ts.ObjectFlags.Reference:
-      //     const t = type as ts.TypeReference;
-      //     console.log(
-      //       "target",
-      //       checker.typeToString(t.target),
-      //       (t.target as ts.TypeReference).node
-      //     );
 
-      //     console.log("node", t.node);
-      //     break;
-      //   case ts.ObjectFlags.ArrayLiteral:
-      //     console.log("isArrray");
-      // }
-      return `{ ${checker
-        .getPropertiesOfType(type)
-        .map((prop) => {
-          // console.log("prop", prop.getName(), prop);
-          // console.log(checker.getTypeAtLocation(prop.valueDeclaration));
-          return `${toValueCase(prop.getName())} : ${buildType(
-            checker.getTypeAtLocation(prop.valueDeclaration),
-            checker
+      console.log(
+        "target",
+        checker.typeToString(type),
+        (type as ts.ObjectType).objectFlags,
+        type.aliasSymbol
+      );
+      if (type.aliasSymbol) {
+        // let refType = checker.getSignaturesOfType(type, ts.SignatureKind.);
+        // let refType = checker.getTypeAtLocation(
+        //   (type.aliasSymbol.declarations?.[0] as ts.TypeAliasDeclaration).type!
+        // );
+        console.log(type.aliasSymbol);
+        const args =
+          type.aliasTypeArguments?.map((arg) =>
+            buildType(arg, checker, node)
+          ) ?? [];
+        console.log(
+          "declared",
+          checker.getDeclaredTypeOfSymbol(type.aliasSymbol)
+        );
+        let refType = checker.getDeclaredTypeOfSymbol(type.aliasSymbol);
+        // return;
+        // console.log("refType", refType);
+        let ref = elm`type alias ${toTypeCase(type.aliasSymbol.name)}${
+          refType.aliasTypeArguments == null
+            ? ""
+            : " " +
+              refType.aliasTypeArguments
+                .map((arg): string => toValueCase(arg.symbol.name))
+                .join(" ")
+        } = ${buildObjectDefinition(refType, checker, node)}`;
+
+        let begin = {
+          expression: toTypeCase(type.aliasSymbol.name),
+          definitions: new Map([
+            [type.aliasSymbol.name, ref.expression],
+            ...ref.definitions.entries(),
+          ]),
+        };
+
+        return join([begin, ...args], " ");
+      }
+
+      let ref;
+      switch ((type as ts.ObjectType).objectFlags) {
+        case ts.ObjectFlags.Interface:
+          ref = elm`type alias ${type.symbol.name} = ${buildObjectDefinition(
+            type,
+            checker,
+            node
           )}`;
-        })
-        .join(", ")} }`;
+          return {
+            expression: type.symbol.name,
+            definitions: new Map([
+              [type.symbol.name, ref.expression],
+              ...ref.definitions,
+            ]),
+          };
+        case ts.ObjectFlags.Reference:
+          const t = type as ts.TypeReference;
+          const args =
+            t.typeArguments?.map((arg) => buildType(arg, checker, node)) ?? [];
+
+          console.log(args);
+
+          ref = elm`type alias ${toTypeCase(t.target.symbol.name)}${
+            t.target.typeArguments == null
+              ? ""
+              : " " +
+                t.target.typeArguments
+                  .map((arg): string => toValueCase(arg.symbol.name))
+                  .join(" ")
+          } = ${buildObjectDefinition(t.target, checker, node)}`;
+
+          let begin = {
+            expression: toTypeCase(t.symbol.name),
+            definitions: new Map([
+              [t.target.symbol.name, ref.expression],
+              ...ref.definitions.entries(),
+            ]),
+          };
+
+          return join([begin, ...args], " ");
+        case ts.ObjectFlags.ArrayLiteral:
+          console.log("isArrray");
+      }
+      return buildObjectDefinition(type, checker, node);
 
     case ts.TypeFlags.Union:
       return todo("Union");

--- a/src/elm/type.ts
+++ b/src/elm/type.ts
@@ -1,5 +1,5 @@
 import * as ts from "typescript";
-import { toTypeCase, toValueCase } from "./utils";
+import { toTypeCase, toValueCase, enumInfo, tupleElements } from "./utils";
 import { TransformError, nodeFromType } from "../error";
 
 export type Type = {
@@ -99,7 +99,23 @@ export const buildType = (
     throw new TransformError(node, message);
   };
 
-  const todo = (name: string) => error(`Type ${name} not implemented`);
+  // A TypeScript `enum` arrives as a union of EnumLiteral members (not
+  // TypeFlags.Enum), so it is detected before the flag switch. It becomes an
+  // Elm custom type with one nullary constructor per member.
+  const enumType = enumInfo(type, checker);
+  if (enumType) {
+    const docs = buildDocs(
+      (type.aliasSymbol ?? type.symbol)!,
+      checker
+    );
+    const definition = `${docs}type ${enumType.name} = ${enumType.members
+      .map((member) => member.constructor)
+      .join(" | ")}`;
+    return {
+      expression: enumType.name,
+      definitions: new Map([[enumType.name + "(..)", definition]]),
+    };
+  }
 
   switch (type.flags) {
     case ts.TypeFlags.Any:
@@ -115,8 +131,8 @@ export const buildType = (
     case ts.TypeFlags.Boolean:
     case ts.TypeFlags.Boolean | ts.TypeFlags.Union:
       return elm`Bool`;
-    case ts.TypeFlags.Enum:
-      return todo("Enum");
+    // Enums are handled by the enumInfo guard above; they never reach here with
+    // a bare TypeFlags.Enum, so there is no case for it.
 
     case ts.TypeFlags.BigInt:
     case ts.TypeFlags.BigIntLiteral:
@@ -153,6 +169,21 @@ export const buildType = (
           checker,
           node
         )})`;
+      }
+
+      // A TypeScript tuple maps to an Elm tuple. Elm only has 2- and 3-tuples,
+      // so other arities are rejected.
+      const tupleTypes = tupleElements(type, checker);
+      if (tupleTypes) {
+        if (tupleTypes.length < 2 || tupleTypes.length > 3) {
+          error(
+            `Tuples with ${tupleTypes.length} elements are not supported; Elm only has 2- and 3-element tuples (consider a record instead)`
+          );
+        }
+        return elm`( ${join(
+          tupleTypes.map((el) => buildType(el, checker, node)),
+          ", "
+        )} )`;
       }
 
       // A string index signature (`Record<string, X>` or `{ [key: string]: X }`)

--- a/src/elm/type.ts
+++ b/src/elm/type.ts
@@ -6,13 +6,15 @@ import {
   tupleElements,
   templateLiteralInfo,
   propertyTypeNode,
-  isElmInt,
+  customTypeInfo,
 } from "./utils";
 import { TransformError, nodeFromType } from "../error";
 
 export type Type = {
   expression: string;
   definitions: Map<string, string>;
+  /** Elm import lines required by custom types nested anywhere in this type. */
+  imports?: string[];
 };
 
 const elm = (
@@ -36,6 +38,9 @@ const elm = (
       values.flatMap((v) =>
         typeof v == "string" ? [] : Array.from(v.definitions?.entries())
       )
+    ),
+    imports: values.flatMap((v) =>
+      typeof v == "string" ? [] : v.imports ?? []
     ),
   };
 };
@@ -117,10 +122,16 @@ export const buildType = (
     throw new TransformError(node, message);
   };
 
-  // The branded `Int` type presents as an intersection (number & brand), so it
-  // is detected before both the flag switch and the Intersection→record case.
-  if (isElmInt(type, checker)) {
-    return elm`Int`;
+  // A user-defined `ElmType<...>` brand (including the built-in `Int`) maps to
+  // an arbitrary Elm type. Detected before the enum/Intersection handling since
+  // it too presents as an intersection.
+  const customType = customTypeInfo(type, checker);
+  if (customType) {
+    return {
+      expression: customType.typeName,
+      definitions: new Map(),
+      imports: customType.modules.map((m) => `import ${m}`),
+    };
   }
 
   // A TypeScript `enum` arrives as a union of EnumLiteral members (not
@@ -296,6 +307,7 @@ ${ctor} raw =
             [toTypeCase(type.aliasSymbol.name), ref.expression],
             ...ref.definitions.entries(),
           ]),
+          imports: ref.imports,
         };
 
         return join([begin, ...args], " ");
@@ -319,6 +331,7 @@ ${ctor} raw =
               [toTypeCase(type.symbol.name), ref.expression],
               ...ref.definitions,
             ]),
+            imports: ref.imports,
           };
         case ts.ObjectFlags.Reference:
           const t = type as ts.TypeReference;
@@ -351,6 +364,7 @@ ${ctor} raw =
               [toTypeCase(t.target.symbol.name), ref.expression],
               ...ref.definitions.entries(),
             ]),
+            imports: ref.imports,
           };
 
           return join([begin, ...args], " ");

--- a/src/elm/type.ts
+++ b/src/elm/type.ts
@@ -1,5 +1,13 @@
 import * as ts from "typescript";
-import { toTypeCase, toValueCase, enumInfo, tupleElements } from "./utils";
+import {
+  toTypeCase,
+  toValueCase,
+  enumInfo,
+  tupleElements,
+  templateLiteralInfo,
+  propertyTypeNode,
+  isElmInt,
+} from "./utils";
 import { TransformError, nodeFromType } from "../error";
 
 export type Type = {
@@ -47,7 +55,8 @@ const buildObjectDefinition = (
   type: ts.Type,
   checker: ts.TypeChecker,
   lastNode: ts.Node,
-  filterOutLiterals: boolean
+  filterOutLiterals: boolean,
+  inbound = false
 ): Type => {
   return elm`{ ${join(
     checker
@@ -61,8 +70,12 @@ const buildObjectDefinition = (
         return elm`${toValueCase(prop.getName())} : ${buildType(
           checker.getTypeAtLocation(prop.valueDeclaration!),
           checker,
-          lastNode,
-          false
+          // Prefer the property's own type-reference node so nested types that
+          // rely on their reference site (e.g. template literals) resolve their
+          // name; fall back to the enclosing node otherwise.
+          propertyTypeNode(prop) ?? lastNode,
+          false,
+          inbound
         )}`;
       }),
     ", "
@@ -88,7 +101,12 @@ export const buildType = (
   type: ts.Type,
   checker: ts.TypeChecker,
   lastNode: ts.Node,
-  filterOutLiterals = false
+  filterOutLiterals = false,
+  // When the value flows *into* Elm (an event payload we decode) rather than
+  // out of it, template literal types become a plain `String`: the opaque
+  // newtype's constructor is not exposed, so a decoded opaque value would be
+  // useless to the user. Outbound (property) values keep the validating newtype.
+  inbound = false
 ): Type => {
   // Blame the type's own declaration when it lives in the user's code,
   // otherwise fall back to the referencing node so errors never point into
@@ -98,6 +116,12 @@ export const buildType = (
   const error = (message: string): never => {
     throw new TransformError(node, message);
   };
+
+  // The branded `Int` type presents as an intersection (number & brand), so it
+  // is detected before both the flag switch and the Intersection→record case.
+  if (isElmInt(type, checker)) {
+    return elm`Int`;
+  }
 
   // A TypeScript `enum` arrives as a union of EnumLiteral members (not
   // TypeFlags.Enum), so it is detected before the flag switch. It becomes an
@@ -109,11 +133,46 @@ export const buildType = (
       checker
     );
     const definition = `${docs}type ${enumType.name} = ${enumType.members
-      .map((member) => member.constructor)
+      .map((member) => member.ctor)
       .join(" | ")}`;
     return {
       expression: enumType.name,
       definitions: new Map([[enumType.name + "(..)", definition]]),
+    };
+  }
+
+  // A template literal type (e.g. `` `item-${string}` ``) becomes an opaque Elm
+  // newtype guarded by a smart constructor that rejects non-matching strings.
+  // The type is exposed opaquely (no `(..)`), alongside its constructor.
+  const templateLiteral = templateLiteralInfo(type, checker, lastNode);
+  if (templateLiteral) {
+    // Inbound: the user receives the value but can't unwrap an opaque type, so
+    // hand them a plain String (matching the decoder, which decodes a String).
+    // Any template literal is a string at runtime, so this works regardless of
+    // whether the outbound opaque-newtype form would be supported.
+    if (inbound) {
+      return elm`String`;
+    }
+    if (!templateLiteral.supported) {
+      return error(templateLiteral.reason);
+    }
+    const { name, ctor, pattern, validator } = templateLiteral;
+    const typeDef = `type ${name}
+    = ${name} String`;
+    const ctorDef = `{-| Build a \`${name}\` from a \`String\`, returning \`Nothing\` if it does not match the TypeScript type ${pattern}. -}
+${ctor} : String -> Maybe ${name}
+${ctor} raw =
+    if ${validator} then
+        Just (${name} raw)
+
+    else
+        Nothing`;
+    return {
+      expression: name,
+      definitions: new Map([
+        [name, typeDef],
+        [ctor, ctorDef],
+      ]),
     };
   }
 
@@ -167,7 +226,9 @@ export const buildType = (
         return elm`List (${buildType(
           checker.getTypeArguments(type as ts.TypeReference)[0],
           checker,
-          node
+          node,
+          false,
+          inbound
         )})`;
       }
 
@@ -181,7 +242,7 @@ export const buildType = (
           );
         }
         return elm`( ${join(
-          tupleTypes.map((el) => buildType(el, checker, node)),
+          tupleTypes.map((el) => buildType(el, checker, node, false, inbound)),
           ", "
         )} )`;
       }
@@ -194,13 +255,19 @@ export const buildType = (
         ts.IndexKind.String
       );
       if (stringIndexType && checker.getPropertiesOfType(type).length === 0) {
-        return elm`Dict String (${buildType(stringIndexType, checker, node)})`;
+        return elm`Dict String (${buildType(
+          stringIndexType,
+          checker,
+          node,
+          false,
+          inbound
+        )})`;
       }
 
       if (type.aliasSymbol) {
         const args =
           type.aliasTypeArguments?.map((arg) =>
-            buildType(arg, checker, node)
+            buildType(arg, checker, node, false, inbound)
           ) ?? [];
 
         let refType = checker.getDeclaredTypeOfSymbol(type.aliasSymbol);
@@ -219,7 +286,8 @@ export const buildType = (
           refType,
           checker,
           node,
-          filterOutLiterals
+          filterOutLiterals,
+          inbound
         )}`;
 
         let begin = {
@@ -242,7 +310,8 @@ export const buildType = (
             type,
             checker,
             node,
-            filterOutLiterals
+            filterOutLiterals,
+            inbound
           )}`;
           return {
             expression: type.symbol.name,
@@ -254,7 +323,9 @@ export const buildType = (
         case ts.ObjectFlags.Reference:
           const t = type as ts.TypeReference;
           const args =
-            t.typeArguments?.map((arg) => buildType(arg, checker, node)) ?? [];
+            t.typeArguments?.map((arg) =>
+              buildType(arg, checker, node, false, inbound)
+            ) ?? [];
 
           ref = elm`${buildDocs(
             t.target.symbol,
@@ -270,7 +341,8 @@ export const buildType = (
             t.target,
             checker,
             node,
-            filterOutLiterals
+            filterOutLiterals,
+            inbound
           )}`;
 
           let begin = {
@@ -285,7 +357,13 @@ export const buildType = (
         case ts.ObjectFlags.ArrayLiteral:
           console.log("isArrray");
       }
-      return buildObjectDefinition(type, checker, node, filterOutLiterals);
+      return buildObjectDefinition(
+        type,
+        checker,
+        node,
+        filterOutLiterals,
+        inbound
+      );
 
     case ts.TypeFlags.Union:
       if (type.aliasSymbol) {
@@ -325,7 +403,7 @@ export const buildType = (
                       )!
                   )
                   .find((ts) => ts.isStringLiteral())?.value ?? ""
-              )} (${buildType(t, checker, node, true)})`;
+              )} (${buildType(t, checker, node, true, inbound)})`;
             }),
             " | "
           )}`;
@@ -347,13 +425,19 @@ export const buildType = (
           const subtype = t.types.find(
             (t) => t.flags !== ts.TypeFlags.Undefined
           );
-          return elm`Maybe (${buildType(subtype!, checker, node)})`;
+          return elm`Maybe (${buildType(
+            subtype!,
+            checker,
+            node,
+            false,
+            inbound
+          )})`;
         }
         error("Anonymous union types not supported");
       }
 
     case ts.TypeFlags.Intersection:
-      return buildObjectDefinition(type, checker, node, false);
+      return buildObjectDefinition(type, checker, node, false, inbound);
 
     // case ts.TypeFlags.Index:
     //   // TODO: ???

--- a/src/elm/utils.ts
+++ b/src/elm/utils.ts
@@ -3,7 +3,7 @@ import * as ts from "typescript";
 
 export type EnumMember = {
   /** The Elm custom-type constructor name, e.g. `Red`. */
-  constructor: string;
+  ctor: string;
   /** The value each member serializes to (string enums) or its ordinal (numeric enums). */
   value: string | number;
 };
@@ -14,6 +14,45 @@ export type EnumInfo = {
   members: EnumMember[];
   /** Whether members serialize to JSON strings (vs. numbers). */
   isString: boolean;
+};
+
+/**
+ * The type-annotation node of a property (e.g. the `Size` in `size: Size`),
+ * used to recover alias names that TypeScript resolves away (template literals).
+ * Returns `undefined` when the property has no explicit type node.
+ */
+export const propertyTypeNode = (prop: ts.Symbol): ts.Node | undefined => {
+  const declaration = prop.valueDeclaration;
+  if (
+    declaration &&
+    (ts.isPropertySignature(declaration) ||
+      ts.isPropertyDeclaration(declaration)) &&
+    declaration.type
+  ) {
+    return declaration.type;
+  }
+  return undefined;
+};
+
+/** The brand property carried by the library's `Int` type. */
+const ELM_INT_BRAND = "__elmInt__";
+
+/**
+ * Detects the library's branded `Int` type (`number & { __elmInt__?: never }`),
+ * which the user uses to request an Elm `Int` instead of a `Float`. It presents
+ * to the checker as an intersection of a `number` and a brand object carrying
+ * the {@link ELM_INT_BRAND} property, and is detected structurally so it also
+ * works when nested inside records, tuples, arrays, etc.
+ */
+export const isElmInt = (type: ts.Type, checker: ts.TypeChecker): boolean => {
+  if (!type.isIntersection()) {
+    return false;
+  }
+  const hasNumber = type.types.some((m) => (m.flags & ts.TypeFlags.Number) !== 0);
+  const hasBrand = type.types.some((m) =>
+    checker.getPropertiesOfType(m).some((p) => p.getName() === ELM_INT_BRAND)
+  );
+  return hasNumber && hasBrand;
 };
 
 /**
@@ -29,6 +68,116 @@ export const tupleElements = (
     return null;
   }
   return checker.getTypeArguments(type as ts.TypeReference).slice();
+};
+
+export type TemplateLiteralInfo = {
+  /** Whether this template literal maps to a supported opaque Elm newtype. */
+  supported: boolean;
+  /** When unsupported, a human-readable explanation for the error. */
+  reason?: string;
+  /** Opaque Elm type name, e.g. `ItemId` (present when supported). */
+  name?: string;
+  /** Smart-constructor name, e.g. `itemId` (present when supported). */
+  ctor?: string;
+  /** The original TS pattern, e.g. `` `item-${string}` ``. */
+  pattern?: string;
+  /**
+   * Boolean Elm expression validating a `String` bound to `raw`, e.g.
+   * `String.startsWith "item-" raw` (present when supported).
+   */
+  validator?: string;
+};
+
+/**
+ * Classifies a TypeScript template-literal type (e.g. `` `item-${string}` ``).
+ * Returns `null` when `type` is not a template literal. When it is, only the
+ * "core" tier is supported for now: a single `string`/`number` placeholder in a
+ * type that is behind a named alias, with at least one literal anchor. Such a
+ * type maps to an opaque Elm newtype with a `Maybe`-returning smart constructor
+ * that rejects strings not matching the pattern, validated with `elm/core`
+ * String functions (no extra dependency). Anything else returns
+ * `{ supported: false }` with a human-readable reason.
+ */
+export const templateLiteralInfo = (
+  type: ts.Type,
+  checker: ts.TypeChecker,
+  node?: ts.Node
+): TemplateLiteralInfo | null => {
+  if (!(type.flags & ts.TypeFlags.TemplateLiteral)) {
+    return null;
+  }
+  const tl = type as ts.TemplateLiteralType;
+  const patternText = checker.typeToString(type);
+
+  // TypeScript eagerly resolves template-literal aliases and drops the
+  // aliasSymbol, so the alias name only survives on the referencing node (a
+  // `type Foo = ...` used as `Foo`). Recover it from there — but only when the
+  // node genuinely resolves to *this* type, so we never mislabel a nested
+  // template literal with an enclosing type's name. Without a name we have
+  // nothing to call the opaque Elm type, so it is unsupported.
+  const aliasName =
+    node &&
+    ts.isTypeReferenceNode(node) &&
+    checker.getTypeAtLocation(node) === type
+      ? checker.getSymbolAtLocation(node.typeName)?.name
+      : undefined;
+  if (!aliasName) {
+    return {
+      supported: false,
+      reason: `anonymous template literal types are not supported; declare it as a named \`type\` and refer to it by name (pattern: ${patternText})`,
+    };
+  }
+  if (tl.types.length !== 1) {
+    return {
+      supported: false,
+      reason: `template literal types with more than one placeholder are not yet supported (pattern: ${patternText})`,
+    };
+  }
+
+  const placeholder = tl.types[0];
+  const isNumber = (placeholder.flags & ts.TypeFlags.Number) !== 0;
+  const isString = (placeholder.flags & ts.TypeFlags.String) !== 0;
+  if (!isNumber && !isString) {
+    return {
+      supported: false,
+      reason: `only \`string\` and \`number\` template-literal placeholders are supported (pattern: ${patternText})`,
+    };
+  }
+
+  const prefix = tl.texts[0];
+  const suffix = tl.texts[1];
+  if (!prefix && !suffix) {
+    return {
+      supported: false,
+      reason: `unanchored template literal is equivalent to a plain \`${
+        isNumber ? "number" : "string"
+      }\` and adds no constraint (pattern: ${patternText})`,
+    };
+  }
+
+  const escape = (s: string) => s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  const checks: string[] = [];
+  if (prefix) checks.push(`String.startsWith "${escape(prefix)}" raw`);
+  if (suffix) checks.push(`String.endsWith "${escape(suffix)}" raw`);
+  if (prefix && suffix) {
+    // Guard against prefix/suffix overlapping on a too-short string.
+    checks.push(`String.length raw >= ${prefix.length + suffix.length}`);
+  }
+  if (isNumber) {
+    // The span between the anchors must itself parse as a number.
+    let expr = "raw";
+    if (suffix) expr = `String.dropRight ${suffix.length} (${expr})`;
+    if (prefix) expr = `String.dropLeft ${prefix.length} (${expr})`;
+    checks.push(`(String.toFloat (${expr}) /= Nothing)`);
+  }
+
+  return {
+    supported: true,
+    name: toTypeCase(aliasName),
+    ctor: toValueCase(aliasName),
+    pattern: patternText,
+    validator: checks.join(" && "),
+  };
 };
 
 /**
@@ -51,7 +200,7 @@ export const enumInfo = (
   const members = type.types.map((member): EnumMember => {
     const literal = member as ts.LiteralType;
     return {
-      constructor: toTypeCase(member.symbol?.name ?? ""),
+      ctor: toTypeCase(member.symbol?.name ?? ""),
       value: literal.value as string | number,
     };
   });

--- a/src/elm/utils.ts
+++ b/src/elm/utils.ts
@@ -34,25 +34,76 @@ export const propertyTypeNode = (prop: ts.Symbol): ts.Node | undefined => {
   return undefined;
 };
 
-/** The brand property carried by the library's `Int` type. */
-const ELM_INT_BRAND = "__elmInt__";
+export type CustomTypeInfo = {
+  /** The Elm type expression, e.g. `Time.Posix`. */
+  typeName: string;
+  /** A complete `Decoder` expression, emitted verbatim; `""` if not provided. */
+  decoder: string;
+  /** A `X -> Encode.Value` function applied to the value; `""` if not provided. */
+  encoder: string;
+  /** Fully-qualified Elm module names to `import` (unqualified). */
+  modules: string[];
+};
+
+/** Reads a string-literal-typed property off any member of an intersection. */
+const readStringBrand = (
+  type: ts.Type,
+  checker: ts.TypeChecker,
+  propName: string
+): string | undefined => {
+  if (!type.isIntersection()) {
+    return undefined;
+  }
+  for (const member of type.types) {
+    const prop = checker.getPropertyOfType(member, propName);
+    if (prop) {
+      const propType = checker.getTypeOfSymbol(prop);
+      if (propType.isStringLiteral()) {
+        return propType.value;
+      }
+    }
+  }
+  return undefined;
+};
 
 /**
- * Detects the library's branded `Int` type (`number & { __elmInt__?: never }`),
- * which the user uses to request an Elm `Int` instead of a `Float`. It presents
- * to the checker as an intersection of a `number` and a brand object carrying
- * the {@link ELM_INT_BRAND} property, and is detected structurally so it also
- * works when nested inside records, tuples, arrays, etc.
+ * Detects a user-defined `ElmType<...>` brand (see the library's `ElmType`),
+ * which maps a TypeScript type to an arbitrary Elm type with its own decoder,
+ * encoder and modules. Returns the extracted mapping, or `null` if `type` is not
+ * such a brand. `decoder`/`encoder` are `""` when the user omitted them.
+ * Detected structurally, so it works nested anywhere.
  */
-export const isElmInt = (type: ts.Type, checker: ts.TypeChecker): boolean => {
-  if (!type.isIntersection()) {
-    return false;
+export const customTypeInfo = (
+  type: ts.Type,
+  checker: ts.TypeChecker
+): CustomTypeInfo | null => {
+  const typeName = readStringBrand(type, checker, "__elmType__");
+  // A genuine ElmType brand always carries the decoder/encoder brand props (as
+  // string literals, possibly empty); their absence means this isn't one.
+  const decoder = readStringBrand(type, checker, "__elmDecoder__");
+  const encoder = readStringBrand(type, checker, "__elmEncoder__");
+  if (typeName == null || decoder == null || encoder == null) {
+    return null;
   }
-  const hasNumber = type.types.some((m) => (m.flags & ts.TypeFlags.Number) !== 0);
-  const hasBrand = type.types.some((m) =>
-    checker.getPropertiesOfType(m).some((p) => p.getName() === ELM_INT_BRAND)
-  );
-  return hasNumber && hasBrand;
+
+  // The modules brand is a tuple of string literals (defaulting to empty).
+  let modules: string[] = [];
+  if (type.isIntersection()) {
+    for (const member of type.types) {
+      const prop = checker.getPropertyOfType(member, "__elmModules__");
+      if (prop) {
+        const propType = checker.getTypeOfSymbol(prop);
+        if (checker.isTupleType(propType)) {
+          modules = checker
+            .getTypeArguments(propType as ts.TypeReference)
+            .map((el) => (el.isStringLiteral() ? el.value : ""))
+            .filter((s) => s !== "");
+        }
+      }
+    }
+  }
+
+  return { typeName, decoder, encoder, modules };
 };
 
 /**

--- a/src/elm/utils.ts
+++ b/src/elm/utils.ts
@@ -1,4 +1,66 @@
 import { capitalize, camel, pascal, title } from "radash";
+import * as ts from "typescript";
+
+export type EnumMember = {
+  /** The Elm custom-type constructor name, e.g. `Red`. */
+  constructor: string;
+  /** The value each member serializes to (string enums) or its ordinal (numeric enums). */
+  value: string | number;
+};
+
+export type EnumInfo = {
+  /** Elm type name, e.g. `Color`. */
+  name: string;
+  members: EnumMember[];
+  /** Whether members serialize to JSON strings (vs. numbers). */
+  isString: boolean;
+};
+
+/**
+ * If `type` is a TypeScript tuple (`[A, B]`, `[x: number, y: number]`, ...),
+ * returns its element types; otherwise `null`. Elm only has 2- and 3-tuples,
+ * so callers must reject other arities.
+ */
+export const tupleElements = (
+  type: ts.Type,
+  checker: ts.TypeChecker
+): ts.Type[] | null => {
+  if (!checker.isTupleType(type)) {
+    return null;
+  }
+  return checker.getTypeArguments(type as ts.TypeReference).slice();
+};
+
+/**
+ * A TypeScript `enum` presents to the checker as a `Union` of `EnumLiteral`
+ * members rather than `TypeFlags.Enum`. When `type` is such a union this returns
+ * the info needed to generate an Elm custom type, encoder and decoder; otherwise
+ * it returns `null`.
+ */
+export const enumInfo = (
+  type: ts.Type,
+  checker: ts.TypeChecker
+): EnumInfo | null => {
+  if (!(type.flags & ts.TypeFlags.EnumLiteral) || !type.isUnion()) {
+    return null;
+  }
+  const symbol = type.aliasSymbol ?? type.symbol;
+  if (!symbol) {
+    return null;
+  }
+  const members = type.types.map((member): EnumMember => {
+    const literal = member as ts.LiteralType;
+    return {
+      constructor: toTypeCase(member.symbol?.name ?? ""),
+      value: literal.value as string | number,
+    };
+  });
+  return {
+    name: toTypeCase(symbol.name),
+    members,
+    isString: type.types.every((member) => member.isStringLiteral()),
+  };
+};
 
 const reservedWords = new Set([
   "if",

--- a/src/elm/utils.ts
+++ b/src/elm/utils.ts
@@ -28,3 +28,35 @@ export const toValueCase = (str: string) => {
 export const toTypeCase = (str: string) => {
   return pascal(title(str));
 };
+export const introduce = (
+  name: string,
+  scope: Map<string, number>
+): [name: string, scope: Map<string, number>] => {
+  let num = scope.get(name);
+  if (num != null) {
+    scope.set(name, num + 1);
+    return [`${name}${num + 1}`, scope];
+  } else {
+    let newScope = new Map(scope);
+    newScope.set(name, 0);
+    return [name, newScope];
+  }
+};
+
+export const buildScope = (names: string[]): Map<string, number> => {
+  let result = new Map<string, number>();
+  for (let name of names) {
+    let match = name.match(/.+?(\d+)$/);
+    let num = 0;
+    if (match != null) {
+      name = name.slice(0, -match[1].length);
+      num = parseInt(match[1]);
+    }
+    if (result.has(name)) {
+      result.set(name, Math.max(result.get(name)!, num));
+    } else {
+      result.set(name, num);
+    }
+  }
+  return result;
+};

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,15 +1,41 @@
 import { DiagnosticsMessage } from "@dev-build-deploy/diagnose-it";
 import * as ts from "typescript";
 
+/**
+ * Finds the most relevant source node to blame for a type, so that errors about
+ * an unsupported type can point at where it was declared. Falls back to the
+ * provided node (e.g. the property that referenced the type) when the type
+ * itself has no declaration, as is the case for primitives.
+ */
+export const nodeFromType = (
+  type: ts.Type,
+  fallback?: ts.Node
+): ts.Node | undefined => {
+  return (
+    type.symbol?.getDeclarations()?.[0] ??
+    type.aliasSymbol?.getDeclarations()?.[0] ??
+    fallback
+  );
+};
+
 export class TransformError extends Error {
   public readonly diagnostic: DiagnosticsMessage;
 
-  constructor(node: ts.Node, message: string) {
+  constructor(node: ts.Node | undefined, message: string) {
+    super(message);
+
+    if (node == null) {
+      // We could not locate the offending type in source; still emit a
+      // diagnostic so the CLI reports a useful message rather than crashing.
+      this.diagnostic = DiagnosticsMessage.createError("<unknown>", {
+        text: message,
+      });
+      return;
+    }
+
     const sourceFile = node.getSourceFile();
     const loc = sourceFile.getLineAndCharacterOfPosition(node.getStart());
     const end = sourceFile.getLineAndCharacterOfPosition(node.getEnd());
-
-    super(message);
 
     const lines = sourceFile
       .getFullText()

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,30 @@
+import { DiagnosticsMessage } from "@dev-build-deploy/diagnose-it";
+import * as ts from "typescript";
+
+export class TransformError extends Error {
+  public readonly diagnostic: DiagnosticsMessage;
+
+  constructor(node: ts.Node, message: string) {
+    const sourceFile = node.getSourceFile();
+    const loc = sourceFile.getLineAndCharacterOfPosition(node.getStart());
+    const end = sourceFile.getLineAndCharacterOfPosition(node.getEnd());
+
+    super(message);
+
+    const lines = sourceFile
+      .getFullText()
+      .split("\n")
+      .slice(Math.max(0, loc.line - 2), end.line + 2)
+      .join("\n");
+
+    this.diagnostic = DiagnosticsMessage.createError(sourceFile.fileName, {
+      text: message,
+      linenumber: loc.line + 1,
+      column: loc.character + 1,
+    }).setContext(Math.max(1, loc.line - 1), lines);
+  }
+}
+
+export const handler = (err: TransformError) => {
+  console.error(err.diagnostic.toString());
+};

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,21 +1,31 @@
 import { DiagnosticsMessage } from "@dev-build-deploy/diagnose-it";
 import * as ts from "typescript";
 
+// A declaration that lives in a `.d.ts` file (e.g. the definition of `Record`
+// or `Array` in TypeScript's own lib files) is useless to blame in an error:
+// it points into node_modules rather than the user's code. We only want to
+// point at nodes that come from the sources we are actually processing.
+const isUserNode = (node: ts.Node | undefined): node is ts.Node =>
+  node != null && !node.getSourceFile().isDeclarationFile;
+
 /**
  * Finds the most relevant source node to blame for a type, so that errors about
- * an unsupported type can point at where it was declared. Falls back to the
- * provided node (e.g. the property that referenced the type) when the type
- * itself has no declaration, as is the case for primitives.
+ * an unsupported type can point at where it was used. Prefers the type's own
+ * declaration, but only when that declaration is in the user's own code; for
+ * library types (and primitives, which have no declaration) it falls back to
+ * the provided node, i.e. the place the type was referenced.
  */
 export const nodeFromType = (
   type: ts.Type,
   fallback?: ts.Node
 ): ts.Node | undefined => {
-  return (
+  const declaration =
     type.symbol?.getDeclarations()?.[0] ??
-    type.aliasSymbol?.getDeclarations()?.[0] ??
-    fallback
-  );
+    type.aliasSymbol?.getDeclarations()?.[0];
+  if (isUserNode(declaration)) {
+    return declaration;
+  }
+  return fallback;
 };
 
 export class TransformError extends Error {

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ export class CustomElement<
     name: Name,
     data: Data
   ) {
-    this.dispatchEvent(new CustomEvent(name, data));
+    this.dispatchEvent(new CustomEvent(name, { detail: data }));
   }
 }
 
@@ -137,7 +137,10 @@ function decorator<T, V>(
   if (context.kind === "accessor") {
     return {
       set(this: CustomElement<T>, value: V) {
-        context.access.set.call(this, value);
+        // `access` is the original auto-accessor's { get, set } pair, invoked
+        // with the instance as receiver. (Note: `context.access.set` has the
+        // shape `set(instance, value)` and must NOT be used here.)
+        access.set.call(this, value);
         this.scheduleUpdate?.();
       },
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,16 +127,16 @@ export const component =
     window.customElements.define(tagName, decorated);
   };
 
-function decorator<V>(
+function decorator<T, V>(
   access: any,
   context:
-    | ClassAccessorDecoratorContext<CustomElement, V>
-    | ClassSetterDecoratorContext<CustomElement, V>
-    | ClassFieldDecoratorContext<CustomElement, V>
+    | ClassAccessorDecoratorContext<CustomElement<T>, V>
+    | ClassSetterDecoratorContext<CustomElement<T>, V>
+    | ClassFieldDecoratorContext<CustomElement<T>, V>
 ): any {
   if (context.kind === "accessor") {
     return {
-      set(this: CustomElement, value: V) {
+      set(this: CustomElement<T>, value: V) {
         context.access.set.call(this, value);
         this.scheduleUpdate?.();
       },
@@ -169,9 +169,9 @@ export const required = decorator;
  *
  * @param options.updateAfterSet If set to false, the `update` method will not be called after the value is set.
  */
-export let lazy = <V>(
-  ...args: Parameters<typeof decorator<V>>
-): ReturnType<typeof decorator<V>> => {
+export let lazy = <T, V>(
+  ...args: Parameters<typeof decorator<T, V>>
+): ReturnType<typeof decorator<T, V>> => {
   lazy = decorator;
   if (!window.customElements.get("ewc-value-setter")) {
     window.customElements.define(

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,41 +16,42 @@ export type HtmlContent =
       };
     };
 
+type ConfigBase = {
+  /**
+   * Used to define events that are required arguments to the view function.
+   * Should contain a string literal key with the event name and a value with the type that should be decoded. */
+  requiredEvents?: { [eventName: string]: any };
+  /**
+   * Used to define events that are generated as optional attribute helpers.
+   * Should contain a string literal key with the event name
+   * and a value with the type that should be decoded.
+   * */
+  optionalEvents?: { [eventName: string]: any };
+  /**
+   * Used to define the html content of the element.
+   * If set to "none", the element does not have any html content and will have no such argument.
+   * If set to "single", the element has a single child.
+   * If set to "list", the element has a list of children.
+   * If set to an object, the view function will take HTML content as part of its required arguments record and will render them as slotted content.
+   * */
+  htmlContent?: HtmlContent;
+
+  /**
+   * If the element has no optional attributes/events, set this to false to avoid generating a list of attributes.
+   * This will prevent adding class/id attributes to the element.
+   * */
+  extraAttributes?: boolean;
+};
 /**
  * Base class for defining custom elements.
  */
 export class CustomElement<
-  Config extends {
-    /**
-     * Used to define events that are required arguments to the view function.
-     * Should contain a string literal key with the event name and a value with the type that should be decoded. */
-    requiredEvents?: { [eventName: string]: any };
-    /**
-     * Used to define events that are generated as optional attribute helpers.
-     * Should contain a string literal key with the event name
-     * and a value with the type that should be decoded.
-     * */
-    optionalEvents?: { [eventName: string]: any };
-    /**
-     * Used to define the html content of the element.
-     * If set to "none", the element does not have any html content and will have no such argument.
-     * If set to "single", the element has a single child.
-     * If set to "list", the element has a list of children.
-     * If set to an object, the view function will take HTML content as part of its required arguments record and will render them as slotted content.
-     * */
-    htmlContent?: HtmlContent;
-
-    /**
-     * If the element has no optional attributes/events, set this to false to avoid generating a list of attributes.
-     * This will prevent adding class/id attributes to the element.
-     * */
-    extraAttributes?: boolean;
-  } = {
+  Config extends ConfigBase = {
     requiredEvents: {};
     optionalEvents: {};
     htmlContent: "none";
     extraAttributes: true;
-  }
+  },
 > extends HTMLElement {
   #updateTask = false;
 
@@ -101,14 +102,14 @@ export class CustomElement<
       ? CustomElement<Config>
       : never,
     name: Name,
-    data: Data
+    data: Data,
   ) {
     this.dispatchEvent(new CustomEvent(name, { detail: data }));
   }
 }
 
 function hasUpdate<Sig>(
-  t: CustomElement<any>
+  t: CustomElement<any>,
 ): t is CustomElement<any> & { update: Sig } {
   return "update" in t && typeof t.update === "function";
 }
@@ -127,12 +128,12 @@ export const component =
     window.customElements.define(tagName, decorated);
   };
 
-function decorator<T, V>(
+function decorator<T extends ConfigBase, V>(
   access: any,
   context:
     | ClassAccessorDecoratorContext<CustomElement<T>, V>
     | ClassSetterDecoratorContext<CustomElement<T>, V>
-    | ClassFieldDecoratorContext<CustomElement<T>, V>
+    | ClassFieldDecoratorContext<CustomElement<T>, V>,
 ): any {
   if (context.kind === "accessor") {
     return {
@@ -147,7 +148,7 @@ function decorator<T, V>(
   }
   if (context.kind !== "setter" && context.kind !== "field") {
     throw new Error(
-      "this decorator can only be called on accessors, setters, or fields"
+      "this decorator can only be called on accessors, setters, or fields",
     );
   }
 }
@@ -172,7 +173,7 @@ export const required = decorator;
  *
  * @param options.updateAfterSet If set to false, the `update` method will not be called after the value is set.
  */
-export let lazy = <T, V>(
+export let lazy = <T extends ConfigBase, V>(
   ...args: Parameters<typeof decorator<T, V>>
 ): ReturnType<typeof decorator<T, V>> => {
   lazy = decorator;
@@ -195,7 +196,7 @@ export let lazy = <T, V>(
             el[name] = val;
           }
         }
-      }
+      },
     );
   }
   return decorator(...args);
@@ -205,7 +206,9 @@ export let lazy = <T, V>(
  * This sub class of CustomElement sets up a Shadow DOM for you
  * and includes some utilities for piercing it with styles.
  */
-export class IsolatedCustomElement<T> extends CustomElement<T> {
+export class IsolatedCustomElement<
+  T extends ConfigBase,
+> extends CustomElement<T> {
   #updateTask = false;
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,21 @@
 /**
+ * Marks a `number` that should be generated as an Elm `Int` rather than a
+ * `Float`. TypeScript has no distinct integer type, so this is a branded
+ * `number`: it behaves like a `number` at runtime and in arithmetic, but the
+ * code generator detects the brand and emits `Int` (with `Encode.int` /
+ * `Decode.int`).
+ *
+ * Assigning a numeric literal may require a cast, e.g. `this.count = 5 as Int`.
+ *
+ * @example
+ * ```ts
+ * @required accessor count!: Int;
+ * @required accessor size!: { width: Int; height: Int };
+ * ```
+ */
+export type Int = number & { readonly __elmInt__?: never };
+
+/**
  * Defines how the in Elm the child nodes are going to be passed in.
  */
 export type HtmlContent =

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,12 +41,27 @@ type ConfigBase = {
    * This will prevent adding class/id attributes to the element.
    * */
   extraAttributes?: boolean;
+
+  /**
+   * The name of the generated Elm view function. Defaults to `"view"`.
+   * Set this to a string literal to rename it (e.g. `"container"`).
+   * */
+  viewFnName?: string;
 };
+
+/**
+ * Constrains a config type to _exactly_ the keys of {@link ConfigBase}: any
+ * extra key (e.g. a typo like `htmlContnet`) is mapped to `never`, so it fails
+ * to satisfy the constraint. This turns silently-ignored config keys into
+ * compile errors. Used as an F-bounded constraint: `Config extends NoExcess<Config>`.
+ */
+type NoExcess<Config> = ConfigBase &
+  Record<Exclude<keyof Config, keyof ConfigBase>, never>;
 /**
  * Base class for defining custom elements.
  */
 export class CustomElement<
-  Config extends ConfigBase = {
+  Config extends NoExcess<Config> = {
     requiredEvents: {};
     optionalEvents: {};
     htmlContent: "none";
@@ -128,7 +143,7 @@ export const component =
     window.customElements.define(tagName, decorated);
   };
 
-function decorator<T extends ConfigBase, V>(
+function decorator<T extends NoExcess<T>, V>(
   access: any,
   context:
     | ClassAccessorDecoratorContext<CustomElement<T>, V>
@@ -173,7 +188,7 @@ export const required = decorator;
  *
  * @param options.updateAfterSet If set to false, the `update` method will not be called after the value is set.
  */
-export let lazy = <T extends ConfigBase, V>(
+export let lazy = <T extends NoExcess<T>, V>(
   ...args: Parameters<typeof decorator<T, V>>
 ): ReturnType<typeof decorator<T, V>> => {
   lazy = decorator;
@@ -207,7 +222,7 @@ export let lazy = <T extends ConfigBase, V>(
  * and includes some utilities for piercing it with styles.
  */
 export class IsolatedCustomElement<
-  T extends ConfigBase,
+  T extends NoExcess<T>,
 > extends CustomElement<T> {
   #updateTask = false;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,60 @@
 /**
- * Marks a `number` that should be generated as an Elm `Int` rather than a
- * `Float`. TypeScript has no distinct integer type, so this is a branded
- * `number`: it behaves like a `number` at runtime and in arithmetic, but the
- * code generator detects the brand and emits `Int` (with `Encode.int` /
+ * Maps a TypeScript type to an arbitrary Elm type of your choosing, letting you
+ * plug in Elm types the generator doesn't know about (e.g. `Time.Posix`), or
+ * override the default mapping for a built-in type.
+ *
+ * This is a branded version of a `Base` type: it behaves like `Base` at runtime,
+ * but the generator detects the brand and emits your Elm type, decoder and
+ * encoder instead of the default mapping for `Base`.
+ *
+ * The type parameters are all string literals (or a string tuple) the generator
+ * reads:
+ * - `Name` — the Elm type expression, e.g. `"Time.Posix"`.
+ * - `Decoder` — a complete `Json.Decode.Decoder Name` expression, emitted
+ *   verbatim, e.g. `"Decode.map Time.millisToPosix Decode.int"`. Optional: omit
+ *   it (or pass `""`) for types that only flow *out* of Elm (properties); using
+ *   such a type in an event payload is then a generation error.
+ * - `Encoder` — a `Name -> Json.Encode.Value` function; the generator applies
+ *   it to the value, e.g. `"\\p -> Encode.int (Time.posixToMillis p)"`. Optional
+ *   in the same way, for types that only flow *into* Elm (events).
+ * - `Modules` — fully-qualified Elm module names the snippets reference, e.g.
+ *   `["Time"]`. The generator emits `import <Module>` for each (deduplicated),
+ *   so it always imports them unqualified — avoiding conflicting-alias problems
+ *   between different usages. Note that `Json.Decode as Decode` and
+ *  `Json.Encode as Encode` are guaranteed to be in scope, so do not need to be
+ *  explicitely specified here.
+ *
+ * @example
+ * ```ts
+ * type Posix = ElmType<
+ *   number,
+ *   "Time.Posix",
+ *   "Decode.map Time.millisToPosix Decode.int",
+ *   "\\p -> Encode.int (Time.posixToMillis p)",
+ *   ["Time"]
+ * >;
+ *
+ * @required accessor timestamp!: Posix;
+ * ```
+ */
+export type ElmType<
+  Base,
+  Name extends string,
+  Decoder extends string = "",
+  Encoder extends string = "",
+  Modules extends readonly string[] = [],
+> = Base & {
+  readonly __elmType__: Name;
+  readonly __elmDecoder__: Decoder;
+  readonly __elmEncoder__: Encoder;
+  readonly __elmModules__: Modules;
+};
+
+/**
+ * Marks a `number` that should be generated as an Elm `Int` rather than the
+ * default `Float`. TypeScript has no distinct integer type, so this is a branded
+ * `number` (a special case of {@link ElmType}): it behaves like a `number` at
+ * runtime and in arithmetic, but the generator emits `Int` (with `Encode.int` /
  * `Decode.int`).
  *
  * Assigning a numeric literal may require a cast, e.g. `this.count = 5 as Int`.
@@ -13,7 +65,7 @@
  * @required accessor size!: { width: Int; height: Int };
  * ```
  */
-export type Int = number & { readonly __elmInt__?: never };
+export type Int = ElmType<number, "Int", "Decode.int", "Encode.int">;
 
 /**
  * Defines how the in Elm the child nodes are going to be passed in.

--- a/src/transform.test.ts
+++ b/src/transform.test.ts
@@ -1,0 +1,52 @@
+import { transform } from "./transform";
+import * as ts from "typescript";
+import path from "node:path";
+
+// A self-contained component: the base class and decorator are declared inline
+// so the in-memory program does not need to resolve the real ./index module.
+const COMPONENT = `
+declare function component(name: string): any;
+declare class CustomElement<T> {}
+
+@component("my-element")
+class MyElement extends CustomElement<{}> {}
+`;
+
+const buildProgram = () => {
+  const host = ts.createCompilerHost({});
+  const orig = host.getSourceFile;
+  host.getSourceFile = (fileName, ...args) => {
+    if (fileName === "input.ts") {
+      return ts.createSourceFile(fileName, COMPONENT, ts.ScriptTarget.Latest);
+    }
+    return orig(fileName, ...args);
+  };
+  return ts.createProgram(["input.ts"], { strictNullChecks: true }, host);
+};
+
+describe("module prefix", () => {
+  test("without a prefix, emits a flat module name and file", () => {
+    const output = transform(["input.ts"], buildProgram());
+    expect([...output.keys()]).toEqual(["MyElement.elm"]);
+    expect(output.get("MyElement.elm")).toContain(
+      "module MyElement exposing"
+    );
+  });
+
+  test("with a prefix, nests the module name and path", () => {
+    const output = transform(["input.ts"], buildProgram(), "Components");
+    const expectedPath = ["Components", "MyElement.elm"].join(path.sep);
+    expect([...output.keys()]).toEqual([expectedPath]);
+    expect(output.get(expectedPath)).toContain(
+      "module Components.MyElement exposing"
+    );
+  });
+
+  test("a prefix with a trailing dot is normalized", () => {
+    const output = transform(["input.ts"], buildProgram(), "Components.");
+    const expectedPath = ["Components", "MyElement.elm"].join(path.sep);
+    expect(output.get(expectedPath)).toContain(
+      "module Components.MyElement exposing"
+    );
+  });
+});

--- a/src/transform.test.ts
+++ b/src/transform.test.ts
@@ -50,3 +50,44 @@ describe("module prefix", () => {
     );
   });
 });
+
+describe("custom ElmType imports", () => {
+  const COMPONENT_WITH_CUSTOM = `
+declare function component(name: string): any;
+declare function required(a: any, c: any): any;
+declare class CustomElement<T> {}
+
+type ElmType<Base, Name extends string, Dec extends string = "", Enc extends string = "", Mods extends readonly string[] = []> =
+  Base & { readonly __elmType__: Name; readonly __elmDecoder__: Dec; readonly __elmEncoder__: Enc; readonly __elmModules__: Mods; };
+type Posix = ElmType<number, "Time.Posix", "Decode.map Time.millisToPosix Decode.int", "\\\\p -> Encode.int (Time.posixToMillis p)", ["Time"]>;
+
+@component("clock-element")
+class ClockElement extends CustomElement<{}> {
+  @required accessor start!: Posix;
+}
+`;
+
+  test("a component using a custom type emits the required import", () => {
+    const host = ts.createCompilerHost({});
+    const orig = host.getSourceFile;
+    host.getSourceFile = (fileName, ...args) => {
+      if (fileName === "input.ts") {
+        return ts.createSourceFile(
+          fileName,
+          COMPONENT_WITH_CUSTOM,
+          ts.ScriptTarget.Latest
+        );
+      }
+      return orig(fileName, ...args);
+    };
+    const program = ts.createProgram(
+      ["input.ts"],
+      { strictNullChecks: true },
+      host
+    );
+    const output = transform(["input.ts"], program);
+    const elm = output.get("ClockElement.elm")!;
+    expect(elm).toContain("import Time");
+    expect(elm).toContain("start : Time.Posix");
+  });
+});

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -4,7 +4,7 @@ import * as ts from "typescript";
 import { buildEncoder } from "./elm/encoder";
 import { buildType, type Type as ElmType } from "./elm/type";
 import { buildDecoder } from "./elm/decoder";
-import { toValueCase, toTypeCase } from "./elm/utils";
+import { toValueCase, toTypeCase, buildScope } from "./elm/utils";
 import fs from "node:fs";
 import path from "node:path";
 import { typeDef } from "cmd-ts/dist/cjs/type";
@@ -41,7 +41,7 @@ function extractEventsFromTypeVar(
         name: prop.getName(),
         comment: ts.displayPartsToString(prop.getDocumentationComment(checker)),
         type,
-        elmType: buildType(type, checker, type.symbol.getDeclarations()![0]),
+        elmType: buildType(type, checker, prop.getDeclarations()![0]),
       };
     });
 }
@@ -331,19 +331,19 @@ export const main = ({
   inputFiles: string[];
   outputDir: string;
 }) => {
-  try {
-    const program = ts.createProgram(inputFiles, {});
-    const output = transform(inputFiles, program);
-    [...output.entries()].forEach(([fileName, content]) => {
+  const program = ts.createProgram(inputFiles, {});
+  const output = transform(inputFiles, program);
+  [...output.entries()].forEach(([fileName, content]) => {
+    try {
       fs.writeFileSync(path.join(outputDir, fileName), content);
-    });
-  } catch (e) {
-    if (e instanceof TransformError) {
-      handler(e);
-    } else {
-      throw e;
+    } catch (e) {
+      if (e instanceof TransformError) {
+        handler(e);
+      } else {
+        throw e;
+      }
     }
-  }
+  });
 };
 
 type Attr = { name: string; comment: string; type: ts.Type; elmType: ElmType };
@@ -455,6 +455,19 @@ const formatElmFile = (info: OutputInfo) => {
 
   const requiredArgs = getRequiredArgs(info);
 
+  // this constructs a list of all the names in the module scope and/or the name of one of the main arguments
+  const scopeNames = [
+    ...info.properties.optional.map((oa) => toValueCase(oa.name)),
+    ...info.events.optional.map((oa) => toValueCase(`on ${oa.name}`)),
+    info.viewFnName,
+    ...(info.attributesArg ? ["attrs"] : []),
+    ...(requiredArgs.length > 0 ? ["req"] : []),
+    ...(info.htmlContent == "list" ? ["children"] : ["child"]),
+    ...info.properties.lazy.map((la) => toValueCase(la.name) + "ValueSetter"),
+    "tagger",
+  ];
+  const scope = buildScope(scopeNames);
+
   return `module ${info.moduleName} exposing (${exposing.join(", ")})
 
 {-| ${info.moduleComments}
@@ -480,7 +493,8 @@ ${toValueCase(oa.name)} val =
     Html.Attributes.property "${oa.name}" (${buildEncoder(
         oa.type,
         "val",
-        info.checker
+        info.checker,
+        scope
       )})
 `
   )
@@ -496,7 +510,8 @@ ${toValueCase(`on ${oa.name}`)} : (${
 ${toValueCase(`on ${oa.name}`)} tagger = 
       Html.Events.on "${oa.name}" (Decode.map tagger (${buildDecoder(
         oa.type,
-        info.checker
+        info.checker,
+        scope
       )}))
   `
   )
@@ -540,7 +555,8 @@ ${info.viewFnName} ${info.attributesArg ? "attrs " : ""}${
         `Html.Attributes.property "${ra.name}" (${buildEncoder(
           ra.type,
           `req.${toValueCase(ra.name)}`,
-          info.checker
+          info.checker,
+          scope
         )})`
     )
     .concat(
@@ -548,7 +564,7 @@ ${info.viewFnName} ${info.attributesArg ? "attrs " : ""}${
         (re) =>
           `Html.Events.on "${re.name}" (Decode.map req.${toValueCase(
             `on ${re.name}`
-          )} (${buildDecoder(re.type, info.checker)}))
+          )} (${buildDecoder(re.type, info.checker, scope)}))
       `
       )
     )
@@ -577,7 +593,8 @@ ${toValueCase(la.name)}ValueSetter val =
   }"), Html.Attributes.property "value" (${buildEncoder(
         la.type,
         "val",
-        info.checker
+        info.checker,
+        scope
       )})] []
 `
   )

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -178,7 +178,6 @@ export const transform = (
               );
               if (extraAttributesProp != null) {
                 const t = checker.getTypeOfSymbol(extraAttributesProp);
-                console.log("extraAttributes", checker.typeToString(t));
                 if (checker.typeToString(t) == "false") {
                   extraAttributes = false;
                 }
@@ -314,8 +313,6 @@ export const transform = (
       });
     })
     .filter((x) => x != null) as OutputInfo[];
-
-  console.log(outputInfos);
 
   const output = new Map<string, string>();
   outputInfos.forEach((info) => {
@@ -453,6 +450,7 @@ const formatElmFile = (info: OutputInfo) => {
     ...info.events.optional.map((oa) => toValueCase(`on ${oa.name}`))
   );
 
+  exposing.push(...info.typeDefs.keys());
   const requiredArgs = getRequiredArgs(info);
 
   // this constructs a list of all the names in the module scope and/or the name of one of the main arguments

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -463,6 +463,9 @@ const formatElmFile = (info: OutputInfo) => {
     ...(info.htmlContent == "list" ? ["children"] : ["child"]),
     ...info.properties.lazy.map((la) => toValueCase(la.name) + "ValueSetter"),
     "tagger",
+    // `val` is the parameter name for optional-property and lazy setters, so it
+    // must be reserved to stop nested encoders (e.g. the Maybe branch) shadowing it.
+    "val",
   ];
   const scope = buildScope(scopeNames);
 
@@ -506,11 +509,11 @@ ${toValueCase(`on ${oa.name}`)} : (${
         oa.elmType.expression
       } -> msg) -> Attribute msg
 ${toValueCase(`on ${oa.name}`)} tagger = 
-      Html.Events.on "${oa.name}" (Decode.map tagger (${buildDecoder(
+      Html.Events.on "${oa.name}" (Decode.map tagger (Decode.field "detail" (${buildDecoder(
         oa.type,
         info.checker,
         scope
-      )}))
+      )})))
   `
   )
   .join("\n")}
@@ -562,7 +565,11 @@ ${info.viewFnName} ${info.attributesArg ? "attrs " : ""}${
         (re) =>
           `Html.Events.on "${re.name}" (Decode.map req.${toValueCase(
             `on ${re.name}`
-          )} (${buildDecoder(re.type, info.checker, scope)}))
+          )} (Decode.field "detail" (${buildDecoder(
+            re.type,
+            info.checker,
+            scope
+          )})))
       `
       )
     )

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -353,6 +353,9 @@ export const main = ({
   } catch (e) {
     if (e instanceof TransformError) {
       handler(e);
+      // Signal failure so callers (e.g. a CI codegen step) don't treat an
+      // unsupported type as a successful run.
+      process.exitCode = 1;
     } else {
       throw e;
     }

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -37,11 +37,23 @@ function extractEventsFromTypeVar(
         prop,
         prop.valueDeclaration!
       );
+      const declaration = prop.getDeclarations()![0];
+      // The type-reference node (e.g. the `Foo` in `event: Foo`) carries the
+      // alias name for template-literal types, which the type itself drops.
+      const node =
+        (ts.isPropertySignature(declaration) ||
+          ts.isPropertyDeclaration(declaration)) &&
+        declaration.type
+          ? declaration.type
+          : declaration;
       return {
         name: prop.getName(),
         comment: ts.displayPartsToString(prop.getDocumentationComment(checker)),
         type,
-        elmType: buildType(type, checker, prop.getDeclarations()![0]),
+        node,
+        // Events flow into Elm (decoded), so template literals in the payload
+        // become plain Strings rather than opaque, unusable newtypes.
+        elmType: buildType(type, checker, node, false, true),
       };
     });
 }
@@ -264,6 +276,7 @@ export const transform = (
                   name: propertyNode.name.getText(),
                   comment,
                   type,
+                  node: targetNode,
                   elmType: buildType(type, checker, targetNode),
                 });
               } else if (lazyDecorator) {
@@ -271,6 +284,7 @@ export const transform = (
                   name: propertyNode.name.getText(),
                   comment,
                   type,
+                  node: targetNode,
                   elmType: buildType(type, checker, targetNode),
                 });
               } else if (optionalDecorator) {
@@ -278,6 +292,7 @@ export const transform = (
                   name: propertyNode.name.getText(),
                   comment,
                   type,
+                  node: targetNode,
                   elmType: buildType(type, checker, targetNode),
                 });
               }
@@ -362,7 +377,14 @@ export const main = ({
   }
 };
 
-type Attr = { name: string; comment: string; type: ts.Type; elmType: ElmType };
+type Attr = {
+  name: string;
+  comment: string;
+  type: ts.Type;
+  /** The type-reference node, used to recover alias names TypeScript drops (e.g. template literals). */
+  node: ts.Node;
+  elmType: ElmType;
+};
 
 type AttrList = { optional: Attr[]; required: Attr[] };
 
@@ -485,6 +507,11 @@ const formatElmFile = (info: OutputInfo) => {
     // `val` is the parameter name for optional-property and lazy setters, so it
     // must be reserved to stop nested encoders (e.g. the Maybe branch) shadowing it.
     "val",
+    // Module-level generated names (opaque types and their smart constructors,
+    // enum/union types) must be reserved so decoder lambda parameters rename
+    // around them rather than shadowing (e.g. a `size` field vs. a `size`
+    // smart constructor). Strip the `(..)` exposing suffix some keys carry.
+    ...[...info.typeDefs.keys()].map((key) => key.replace(/\(\.\.\)$/, "")),
   ];
   const scope = buildScope(scopeNames);
 
@@ -530,7 +557,9 @@ ${toValueCase(oa.name)} val =
         oa.type,
         "val",
         info.checker,
-        scope
+        scope,
+        8,
+        oa.node
       )})
 `
   )
@@ -547,7 +576,9 @@ ${toValueCase(`on ${oa.name}`)} tagger =
       Html.Events.on "${oa.name}" (Decode.map tagger (Decode.field "detail" (${buildDecoder(
         oa.type,
         info.checker,
-        scope
+        scope,
+        false,
+        oa.node
       )})))
   `
   )
@@ -592,7 +623,9 @@ ${info.viewFnName} ${info.attributesArg ? "attrs " : ""}${
           ra.type,
           `req.${toValueCase(ra.name)}`,
           info.checker,
-          scope
+          scope,
+          8,
+          ra.node
         )})`
     )
     .concat(
@@ -603,7 +636,9 @@ ${info.viewFnName} ${info.attributesArg ? "attrs " : ""}${
           )} (Decode.field "detail" (${buildDecoder(
             re.type,
             info.checker,
-            scope
+            scope,
+            false,
+            re.node
           )})))
       `
       )
@@ -634,7 +669,9 @@ ${toValueCase(la.name)}ValueSetter val =
         la.type,
         "val",
         info.checker,
-        scope
+        scope,
+        8,
+        la.node
       )})] []
 `
   )

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -302,6 +302,16 @@ export const transform = (
           const getTypeDefs = (attrs: Attr[]) => {
             return attrs.flatMap((attr) => [...attr.elmType.definitions]);
           };
+          const getImports = (attrs: Attr[]) => {
+            return attrs.flatMap((attr) => attr.elmType.imports ?? []);
+          };
+          const allAttrLists = [
+            optionalAttributes,
+            requiredAttributes,
+            lazyAttributes,
+            events.required,
+            events.optional,
+          ];
 
           return {
             viewFnName,
@@ -329,6 +339,10 @@ export const transform = (
               ...getTypeDefs(events.required),
               ...getTypeDefs(events.optional),
             ]),
+            // Imports required by custom `ElmType<...>` mappings, deduplicated.
+            customImports: [
+              ...new Set(allAttrLists.flatMap(getImports)),
+            ],
           };
         }
       });
@@ -399,6 +413,7 @@ type OutputInfo = {
   htmlContent: HtmlContent;
   attributesArg: boolean;
   typeDefs: Map<string, string>;
+  customImports: string[];
 };
 
 const htmlContentToTypeSig = (htmlContent: HtmlContent): string => {
@@ -544,6 +559,7 @@ import Json.Encode as Encode
 import Json.Decode as Decode
 ${usesDict ? "import Dict exposing (Dict)" : ""}
 ${info.properties.lazy.length > 0 ? "import Html.Lazy" : ""}
+${info.customImports.join("\n")}
 
 ${Array.from(info.typeDefs.values()).join("\n\n")}
 

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -48,9 +48,15 @@ function extractEventsFromTypeVar(
 
 export const transform = (
   inputFiles: string[],
-  program: ts.Program
+  program: ts.Program,
+  modulePrefix = ""
 ): Map<string, string> => {
   const checker = program.getTypeChecker();
+  // Normalize the prefix into a trailing-dot form ("Components." or "") so it
+  // can be concatenated directly onto each generated module name.
+  const normalizedPrefix = modulePrefix
+    ? modulePrefix.replace(/\.+$/, "") + "."
+    : "";
   const outputInfos = inputFiles
     .flatMap((fileName) => {
       const ast = program.getSourceFile(fileName);
@@ -290,7 +296,7 @@ export const transform = (
               lazy: lazyAttributes,
             },
             events,
-            moduleName: symbol.getName(),
+            moduleName: normalizedPrefix + symbol.getName(),
             moduleComments: ts.displayPartsToString(
               symbol.getDocumentationComment(checker)
             ),
@@ -316,23 +322,33 @@ export const transform = (
 
   const output = new Map<string, string>();
   outputInfos.forEach((info) => {
-    output.set(info.moduleName + ".elm", formatElmFile(info));
+    // A dotted module name (from --module-prefix) maps to a nested path, since
+    // Elm requires a module's file path to mirror its name.
+    const relativePath = info.moduleName.split(".").join(path.sep) + ".elm";
+    output.set(relativePath, formatElmFile(info));
   });
   return output;
 };
 
 export const main = ({
   outputDir,
+  modulePrefix,
   inputFiles,
 }: {
   inputFiles: string[];
   outputDir: string;
+  modulePrefix?: string;
 }) => {
   try {
     const program = ts.createProgram(inputFiles, { strictNullChecks: true });
-    const output = transform(inputFiles, program);
+    const output = transform(inputFiles, program, modulePrefix);
     [...output.entries()].forEach(([fileName, content]) => {
-      fs.writeFileSync(path.join(outputDir, fileName), content);
+      const target = path.join(outputDir, fileName);
+      // A dotted module prefix maps to nested directories (e.g.
+      // Components.MyElement -> Components/MyElement.elm), so make sure the
+      // subdirectory exists before writing.
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, content);
     });
   } catch (e) {
     if (e instanceof TransformError) {
@@ -469,6 +485,21 @@ const formatElmFile = (info: OutputInfo) => {
   ];
   const scope = buildScope(scopeNames);
 
+  // A `Dict String X` type only appears in the Elm type annotations produced by
+  // buildType (the `Encode.dict`/`Decode.dict` functions live in the Json
+  // modules we already import), so scanning the type expressions and generated
+  // type definitions is enough to decide whether to import `Dict`.
+  const allAttrs = [
+    ...info.properties.optional,
+    ...info.properties.required,
+    ...info.properties.lazy,
+    ...info.events.optional,
+    ...info.events.required,
+  ];
+  const usesDict =
+    allAttrs.some((attr) => /\bDict\b/.test(attr.elmType.expression)) ||
+    Array.from(info.typeDefs.values()).some((def) => /\bDict\b/.test(def));
+
   return `module ${info.moduleName} exposing (${exposing.join(", ")})
 
 {-| ${info.moduleComments}
@@ -481,6 +512,7 @@ import Html.Attributes
 import Html.Events
 import Json.Encode as Encode
 import Json.Decode as Decode
+${usesDict ? "import Dict exposing (Dict)" : ""}
 ${info.properties.lazy.length > 0 ? "import Html.Lazy" : ""}
 
 ${Array.from(info.typeDefs.values()).join("\n\n")}

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -2,11 +2,13 @@ import { query, includes } from "@phenomnomnominal/tsquery";
 
 import * as ts from "typescript";
 import { buildEncoder } from "./elm/encoder";
-import { buildType } from "./elm/type";
+import { buildType, type Type as ElmType } from "./elm/type";
 import { buildDecoder } from "./elm/decoder";
 import { toValueCase, toTypeCase } from "./elm/utils";
 import fs from "node:fs";
 import path from "node:path";
+import { typeDef } from "cmd-ts/dist/cjs/type";
+import { handler, TransformError } from "./error";
 
 type HtmlContent =
   | "none"
@@ -31,10 +33,15 @@ function extractEventsFromTypeVar(
   return checker
     .getPropertiesOfType(checker.getTypeOfSymbol(prop))
     .map((prop) => {
+      const type = checker.getTypeOfSymbolAtLocation(
+        prop,
+        prop.valueDeclaration!
+      );
       return {
         name: prop.getName(),
         comment: ts.displayPartsToString(prop.getDocumentationComment(checker)),
-        type: checker.getTypeOfSymbolAtLocation(prop, prop.valueDeclaration!),
+        type,
+        elmType: buildType(type, checker, type.symbol.getDeclarations()![0]),
       };
     });
 }
@@ -242,27 +249,39 @@ export const transform = (
                 symbol.valueDeclaration!
               );
 
+              const targetNode = query(
+                propertyNode,
+                "TypeReference,SemicolonToken"
+              )[0];
+
               if (requiredDecorator) {
                 requiredAttributes.push({
                   name: propertyNode.name.getText(),
                   comment,
                   type,
+                  elmType: buildType(type, checker, targetNode),
                 });
               } else if (lazyDecorator) {
                 lazyAttributes.push({
                   name: propertyNode.name.getText(),
                   comment,
                   type,
+                  elmType: buildType(type, checker, targetNode),
                 });
               } else if (optionalDecorator) {
                 optionalAttributes.push({
                   name: propertyNode.name.getText(),
                   comment,
                   type,
+                  elmType: buildType(type, checker, targetNode),
                 });
               }
             }
           });
+
+          const getTypeDefs = (attrs: Attr[]) => {
+            return attrs.flatMap((attr) => [...attr.elmType.definitions]);
+          };
 
           return {
             viewFnName,
@@ -283,6 +302,13 @@ export const transform = (
               optionalAttributes.length > 0 ||
               events.optional.length > 0 ||
               extraAttributes,
+            typeDefs: new Map([
+              ...getTypeDefs(optionalAttributes),
+              ...getTypeDefs(requiredAttributes),
+              ...getTypeDefs(lazyAttributes),
+              ...getTypeDefs(events.required),
+              ...getTypeDefs(events.optional),
+            ]),
           };
         }
       });
@@ -305,14 +331,22 @@ export const main = ({
   inputFiles: string[];
   outputDir: string;
 }) => {
-  const program = ts.createProgram(inputFiles, {});
-  const output = transform(inputFiles, program);
-  [...output.entries()].forEach(([fileName, content]) => {
-    fs.writeFileSync(path.join(outputDir, fileName), content);
-  });
+  try {
+    const program = ts.createProgram(inputFiles, {});
+    const output = transform(inputFiles, program);
+    [...output.entries()].forEach(([fileName, content]) => {
+      fs.writeFileSync(path.join(outputDir, fileName), content);
+    });
+  } catch (e) {
+    if (e instanceof TransformError) {
+      handler(e);
+    } else {
+      throw e;
+    }
+  }
 };
 
-type Attr = { name: string; comment: string; type: ts.Type };
+type Attr = { name: string; comment: string; type: ts.Type; elmType: ElmType };
 
 type AttrList = { optional: Attr[]; required: Attr[] };
 
@@ -326,6 +360,7 @@ type OutputInfo = {
   checker: ts.TypeChecker;
   htmlContent: HtmlContent;
   attributesArg: boolean;
+  typeDefs: Map<string, string>;
 };
 
 const htmlContentToTypeSig = (htmlContent: HtmlContent): string => {
@@ -434,11 +469,13 @@ import Json.Encode as Encode
 import Json.Decode as Decode
 ${info.properties.lazy.length > 0 ? "import Html.Lazy" : ""}
 
+${Array.from(info.typeDefs.values()).join("\n\n")}
+
 ${info.properties.optional
   .map(
     (oa) =>
       `{-| ${oa.comment} -}
-${toValueCase(oa.name)} : ${buildType(oa.type, info.checker)} -> Attribute msg
+${toValueCase(oa.name)} : ${oa.elmType.expression} -> Attribute msg
 ${toValueCase(oa.name)} val = 
     Html.Attributes.property "${oa.name}" (${buildEncoder(
         oa.type,
@@ -453,10 +490,9 @@ ${info.events.optional
   .map(
     (oa) =>
       `{-| ${oa.comment} -}
-${toValueCase(`on ${oa.name}`)} : (${buildType(
-        oa.type,
-        info.checker
-      )} -> msg) -> Attribute msg
+${toValueCase(`on ${oa.name}`)} : (${
+        oa.elmType.expression
+      } -> msg) -> Attribute msg
 ${toValueCase(`on ${oa.name}`)} tagger = 
       Html.Events.on "${oa.name}" (Decode.map tagger (${buildDecoder(
         oa.type,
@@ -473,20 +509,13 @@ ${info.viewFnName} : ${info.attributesArg ? "List (Attribute msg) -> " : ""}${
           .map((ra) => {
             switch (ra.kind) {
               case "property":
-                return `${toValueCase(ra.name)} : ${buildType(
-                  ra.type,
-                  info.checker
-                )}`;
+                return `${toValueCase(ra.name)} : ${ra.elmType.expression}`;
               case "lazy":
-                return `${toValueCase(ra.name)} : ${buildType(
-                  ra.type,
-                  info.checker
-                )}`;
+                return `${toValueCase(ra.name)} : ${ra.elmType.expression}`;
               case "event":
-                return `${toValueCase(`on ${ra.name}`)} : ${buildType(
-                  ra.type,
-                  info.checker
-                )} -> msg`;
+                return `${toValueCase(`on ${ra.name}`)} : ${
+                  ra.elmType.expression
+                } -> msg`;
               case "htmlContent":
                 return `${toValueCase(ra.name)} : ${
                   ra.mode == "list" ? "List" : ""
@@ -541,10 +570,7 @@ ${info.viewFnName} ${info.attributesArg ? "attrs " : ""}${
 ${info.properties.lazy
   .map(
     (la) =>
-      `${toValueCase(la.name)}ValueSetter : ${buildType(
-        la.type,
-        info.checker
-      )} -> Html msg
+      `${toValueCase(la.name)}ValueSetter : ${la.elmType.expression} -> Html msg
 ${toValueCase(la.name)}ValueSetter val = 
   Html.node "ewc-value-setter" [ Html.Attributes.property "key" (Encode.string "${
     la.name

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -331,19 +331,19 @@ export const main = ({
   inputFiles: string[];
   outputDir: string;
 }) => {
-  const program = ts.createProgram(inputFiles, {});
-  const output = transform(inputFiles, program);
-  [...output.entries()].forEach(([fileName, content]) => {
-    try {
+  try {
+    const program = ts.createProgram(inputFiles, { strictNullChecks: true });
+    const output = transform(inputFiles, program);
+    [...output.entries()].forEach(([fileName, content]) => {
       fs.writeFileSync(path.join(outputDir, fileName), content);
-    } catch (e) {
-      if (e instanceof TransformError) {
-        handler(e);
-      } else {
-        throw e;
-      }
+    });
+  } catch (e) {
+    if (e instanceof TransformError) {
+      handler(e);
+    } else {
+      throw e;
     }
-  });
+  }
 };
 
 type Attr = { name: string; comment: string; type: ts.Type; elmType: ElmType };


### PR DESCRIPTION
This PR adds:

- [x] a CI step to run basic tests
- [x] better looking error reporting
    <img width="963" alt="Screenshot 2025-02-01 at 23 27 20" src="https://github.com/user-attachments/assets/d9eee4d2-d655-4f80-953a-1562a8b0fdea" />
- [x] much better test coverage
- support for creating type definitions for more complex types, albeit with the following todos:
     - [x] Add proper exposing declarations for the created type definitions
     - [x] Carry over documentation comments from the typescript
- and finally, and most importantly **much** broader type coverage for types, encoders and decoders:
     - [x] Special support for typescript string literal types
     - [x] Support for simple string union types `type some = "foo" | "bar"` becomes `type Some = Foo | Bar` in Elm
     - [x] Support for union types with records as long as they have string literal (`type foo = { tag: "bar", name : string } | { tag: "baz", value : number }` becomes `type Foo = Bar { name : String } | Baz { value : Float }`).
     - [x] Special support for union types with `null` or `undefined`, where `string | null` becomes `Maybe String`.
     - [x] Support for optional fields such as `{ foo?: string }` becomes `{ foo : Maybe String }`
     - [x] Basic support for intersection types
     - [x] Support for various the ways a Dict can be declared in TypeScript
     - [x] Better error messages for unsupported types
- [x] Now we handle shadowing properly, so that generated lambdas never shadow outside scope.
- [x] Handle indentation properly in highly nested situations. 
- [x] Branded Int
- [x] A way to map to customised Elm types 